### PR TITLE
Implement for loops with stride support and intrinsic variables

### DIFF
--- a/air/preload.air
+++ b/air/preload.air
@@ -27,12 +27,12 @@ Bool {
 }
 
 String {
-    downcase {;
-	}
+    downcase {;}
+    upcase {;}
+    length {;}
+}
 
-    upcase {;
-	}
-
-    length {;
-	}
+`todo: This is unused, but here to remind me to think about how to make composing with Iterable behave like Protocols in Swift.
+Iterable {
+	next {;}
 }

--- a/lib/compiler/expressions.rb
+++ b/lib/compiler/expressions.rb
@@ -173,7 +173,7 @@ module Air
 	end
 
 	class For_Loop_Expr < Expression
-		attr_accessor :iterable, :custom_identifier, :stride, :body
+		attr_accessor :collection, :stride, :body
 	end
 
 	class Comment_Expr < Expression

--- a/lib/compiler/parser.rb
+++ b/lib/compiler/parser.rb
@@ -105,34 +105,24 @@ module Air
 		end
 
 		def parse_for_loop_expr
-			# TODO :incomplete
 			eat 'for'
-			it = Air::For_Loop_Expr.new
+			it            = Air::For_Loop_Expr.new
+			it.collection = begin_expression # note: This is intentionally calling only begin_expression, this avoids a full expression like an inline conditional from interfering.
 
-			#
-			# for expr
-			# for expr by integer
-			#
-			# for ident in expr # it.custom_identifier is the ident
-			# for ident in expr by integer
-			#
+			if curr? 'by' and eat 'by'
+				it.stride = begin_expression
+				# ??? should I check that it's a number here?
+			end
 
-			it.iterable = begin_expression # todo, Assert iterable is composed with Iterable, or has the same shape as Iterable.
 			reduce_newlines
 
 			it.body = []
 			until curr? 'end'
 				it.body << parse_expression
 			end
+			it.body = it.body.compact
 
-			# if curr? :identifier, 'in'
-			# 	# for ident in expr
-			# 	# for ident in expr by integer
-			# else
-			# 	# for expr
-			# 	# for expr by integer
-			# end
-
+			eat 'end'
 			it
 		end
 

--- a/test/interpreter_test.rb
+++ b/test/interpreter_test.rb
@@ -1125,4 +1125,42 @@ class Interpreter_Test < Base_Test
 			#load 'test/samples/constants.air'"
 		end
 	end
+
+	def test_for_loop
+		out = Air.interp "
+		NUMBERS = [4, 8, 15, 16, 23, 42]
+		numbers = []
+
+		for NUMBERS
+			numbers << it
+		end
+
+		(numbers == NUMBERS, numbers, NUMBERS)"
+		assert out.values[0]
+	end
+
+	def test_for_loop_by_strides
+		out = Air.interp "
+		NUMBERS = [4, 8, 15, 16, 23, 42]
+		numbers = []
+
+		for NUMBERS by 2
+			numbers << it
+		end
+
+		numbers"
+		assert_equal [[4, 8], [15, 16], [23, 42]], out.values
+	end
+
+	def test_for_loop_at_and_it_intrinsics
+		out = Air.interp "
+		indices = []
+
+		for [4, 8, 15, 16, 23, 42]
+			indices << '|at|: |it|'
+		end
+
+		indices"
+		assert_equal ['0: 4', '1: 8', '2: 15', '3: 16', '4: 23', '5: 42'], out.values
+	end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -722,8 +722,8 @@ class Parser_Test < Base_Test
 		for []
 		end'
 		assert_empty out.first.body
-		assert_instance_of Air::Circumfix_Expr, out.first.iterable # note, The iterable becomes an Array in the interpreter.
-		assert_equal '[]', out.first.iterable.grouping
+		assert_instance_of Air::Circumfix_Expr, out.first.collection # note, The iterable becomes an Array in the interpreter.
+		assert_equal '[]', out.first.collection.grouping
 	end
 
 	def test_import_syntax


### PR DESCRIPTION
Adds for loop syntax with optional stride:
- `for <collection> ... end` - iterate over each element
- `for <collection> by <stride> ... end` - iterate in batches

Provides intrinsic variables in loop scope:
- `it`: current element (or batch when using stride)
- `at`: current index

Fixes `<<` operator to append unwrapped values, ensuring consistency between array literals `[1,2,3]` and dynamic appends `arr << 1`.