### PR TITLE
Add support for multiple servers with separate route collections

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,41 @@ require 'minitest/test_task'
 require_relative 'lib/air'
 require 'pp'
 
+def _interp source_code
+	Air.interp source_code
+end
+
+def _interp_file filepath
+	code        = File.read filepath
+	global      = Air::Global.with_standard_library
+	interpreter = Air::Interpreter.new Air.parse(code), global
+	result      = interpreter.output
+
+	# If servers were started, wait for them and setup signal handlers
+	if interpreter.context.servers.any?
+		servers = interpreter.context.servers
+
+		Signal.trap 'INT' do
+			puts "\nShutting down servers..."
+			servers.each(&:stop)
+			exit 0
+		end
+
+		Signal.trap 'TERM' do
+			puts "\nShutting down servers..."
+			servers.each(&:stop)
+			exit 0
+		end
+
+		puts "Server(s) running. Press Ctrl+C to stop."
+		servers.each do |server|
+			server.server_thread&.join
+		end
+	end
+
+	result
+end
+
 task :default => [:test, :cloc]
 
 Minitest::TestTask.create(:test) do |t|
@@ -20,6 +55,8 @@ task :interp, [:string] do |_, args|
 	end
 
 	pp _interp(args[:string].to_s)
+rescue SystemExit
+	# Interrupt exit
 rescue Exception => e
 	raise "This seems to be broken... Do tests pass? Try `rake`.\n#{e}"
 end
@@ -30,6 +67,8 @@ task :interp_file, [:file] do |_, args|
 	end
 
 	pp _interp_file(args[:file])
+rescue SystemExit
+	# Interrupt exit
 rescue Exception => e
 	raise "This seems to be broken... Do tests pass? Try `rake`.\n#{e}"
 end

--- a/air/server.air
+++ b/air/server.air
@@ -20,24 +20,3 @@ Server {
 		./port = port
 	}
 }
-
-Web_App | Server {
-	get:// {;
-		"Hi!"
-	}
-
-	get://users/:id { id;
-		"<h1>User Profile</h1><p>User ID: |id|</p>"
-	}
-
-	get://greet/:name { name;
-		"<div style='background-color: #e3f2fd; padding: 20px; font-family: sans-serif;'><h1>Hello, |name|!</h1><p>Welcome to Air's protocol-style routing.</p></div>"
-	}
-
-	post://submit/:form_id { form_id;
-		"<h2>Form Submitted</h2><p>Form ID: |form_id|</p><p>Method: |request.method|</p>"
-	}
-}
-
-app = Web_App()
-#serve_http app

--- a/lib/air.rb
+++ b/lib/air.rb
@@ -12,6 +12,7 @@ require_relative 'runtime/errors'
 require_relative 'runtime/scope'
 require_relative 'runtime/types'
 require_relative 'runtime/context'
+require_relative 'runtime/server_runner'
 require_relative 'runtime/interpreter'
 
 module Air

--- a/lib/runtime/scope.rb
+++ b/lib/runtime/scope.rb
@@ -62,7 +62,7 @@ module Air
 	end
 
 	class Type < Scope
-		attr_accessor :expressions, :types
+		attr_accessor :expressions, :types, :routes
 
 		def initialize name = nil
 			super name

--- a/lib/runtime/server_runner.rb
+++ b/lib/runtime/server_runner.rb
@@ -1,0 +1,148 @@
+require 'webrick'
+require 'cgi'
+require_relative '../air'
+
+module Air
+	class Server_Runner
+		attr_accessor :server_instance, :interpreter, :port, :routes, :webrick_server, :server_thread
+
+		def initialize server_instance, interpreter, routes = {}
+			@server_instance = server_instance
+			@interpreter     = interpreter
+			@port            = extract_port
+			@routes          = routes
+		end
+
+		def extract_port
+			port_value = server_instance[:port] || server_instance.declarations['port']
+			port_value.is_a?(Integer) ? port_value : 8080
+		end
+
+		def match_route http_method, path_parts, routes
+			routes.values.find do |route|
+				next unless route.http_method.value == http_method
+				next unless route.parts.count == path_parts.count
+
+				# All segments must match (considering :param placeholders)
+				path_parts.zip(route.parts).all? do |req_part, route_part|
+					(req_part == route_part) || (route_part.start_with?(':'))
+				end
+			end
+		end
+
+		def extract_url_params path_parts, route
+			url_params = {}
+			path_parts.zip(route.parts).each do |req_part, route_part|
+				if route_part.start_with? ':'
+					param_name                    = route_part[1..-1]
+					url_params[param_name]        = req_part
+					url_params[param_name.to_sym] = req_part
+				end
+			end
+			url_params
+		end
+
+		def parse_query_string query_string
+			query_params = {}
+			if query_string
+				query_string.split('&').each do |pair|
+					key, value               = pair.split '=', 2
+					query_params[key]        = CGI.unescape(value || '')
+					query_params[key.to_sym] = CGI.unescape(value || '')
+				end
+			end
+			query_params
+		end
+
+		def handle_request req, res, routes
+			path_string  = req.path
+			query_string = req.query_string
+			http_method  = req.request_method.downcase
+			path_parts   = req.path.split('/').reject { _1.empty? }
+
+			target_route = match_route http_method, path_parts, routes
+
+			if target_route
+				url_params   = extract_url_params path_parts, target_route
+				query_params = parse_query_string query_string
+
+				# Create Request and Response objects
+				air_res = Air::Response.new
+				air_req = Air::Request.new
+
+				air_req.path    = path_string
+				air_req.method  = http_method
+				air_req.query   = query_params
+				air_req.params  = url_params
+				air_req.headers = req.header.to_h
+				air_req.body    = req.body
+
+				# Update declarations
+				air_req.declarations['path']    = air_req.path
+				air_req.declarations['method']  = air_req.method
+				air_req.declarations['query']   = air_req.query
+				air_req.declarations['params']  = air_req.params
+				air_req.declarations['headers'] = air_req.headers
+				air_req.declarations['body']    = air_req.body
+
+				begin
+					result = interpreter.interp_route_handler target_route, air_req, air_res, url_params
+
+					# Apply response object's configuration to WEBrick response
+					res.status = air_res.status
+					air_res.headers.each { |k, v| res.header[k] = v }
+					res.body = air_res.body_content.to_s
+
+				rescue => e
+					res.status = 500
+					res.body   = <<~HTML
+					    <h1>500 Internal Server Error</h1>
+					    <h2>#{e.class}: #{e.message}</h2>
+					    <pre>#{e.backtrace.join("\n")}</pre>
+					HTML
+					res.header['Content-Type'] = 'text/html; charset=utf-8'
+				end
+			else
+				# 404 Not Found
+				res.status = 404
+				res.body   = <<~HTML
+				    <h1>404 Not Found</h1>
+				    <p>No route matches #{http_method.upcase} #{path_string}</p>
+				    <hr>
+				    <h3>Available Routes:</h3>
+				    <ul>
+				    	#{routes.values.map { |r| "<li>#{r.http_method.value.upcase} /#{r.path}</li>" }.join("\n")}
+				    </ul>
+				HTML
+				res.header['Content-Type'] = 'text/html; charset=utf-8'
+			end
+		end
+
+		def start
+			@webrick_server = WEBrick::HTTPServer.new Port: port
+
+			webrick_server.mount_proc '' do |req, res|
+				handle_request req, res, @routes
+			end
+
+			@server_thread = Thread.new do
+				webrick_server.start
+			end
+
+			puts "------------------------------"
+			puts "Server started on port #{port}"
+			puts "Available routes:"
+			@routes.values.each do |route|
+				puts "  #{route.http_method.value.upcase} /#{route.path}"
+			end
+			puts "------------------------------"
+
+			server_thread
+		end
+
+		def stop
+			webrick_server&.shutdown
+			Thread.kill server_thread if server_thread
+		end
+	end
+end

--- a/lib/runtime/types.rb
+++ b/lib/runtime/types.rb
@@ -121,8 +121,9 @@ module Air
 		def initialize
 			super 'Server'
 
+			@routes                 = {}
 			@declarations['port']   = nil
-			@declarations['routes'] = nil
+			@declarations['routes'] = @routes
 		end
 	end
 

--- a/test/e2e_server_test.rb
+++ b/test/e2e_server_test.rb
@@ -1,0 +1,207 @@
+require 'minitest/autorun'
+require_relative '../lib/air'
+require 'net/http'
+require 'uri'
+require 'timeout'
+
+class E2E_Server_Test < Minitest::Test
+	def setup
+		@port = 9999 + Random.rand(100) # Random port to avoid conflicts
+	end
+
+	def teardown
+		# Cleanup any running servers
+		if @server_runner
+			@server_runner.stop
+			sleep 0.1 # Give server time to shutdown
+		end
+	end
+
+	def test_server_starts_and_responds
+		code = <<~AIR
+			Server {
+				port;
+				new { port = #{@port};
+					./port = port
+				}
+			}
+
+			Web_App | Server {
+				get:// {;
+					"Hello from Air!"
+				}
+
+				get://hello/:name { name;
+					"<h1>Hello, |name|!</h1>"
+				}
+			}
+
+			app = Web_App()
+		AIR
+
+		# Start server in background
+		interpreter = Air::Interpreter.new Air.parse(code), Air::Global.with_standard_library
+		server_instance = interpreter.output
+
+		routes = interpreter.collect_routes_from_instance server_instance
+		@server_runner = Air::Server_Runner.new server_instance, interpreter, routes
+		@server_runner.start
+
+		# Give server time to start
+		sleep 0.5
+
+		# Test GET /
+		response = Net::HTTP.get_response URI("http://localhost:#{@port}/")
+		assert_equal '200', response.code
+		assert_equal 'Hello from Air!', response.body
+
+		# Test parameterized route
+		response = Net::HTTP.get_response URI("http://localhost:#{@port}/hello/World")
+		assert_equal '200', response.code
+		assert_includes response.body, 'Hello, World!'
+
+		# Test 404
+		response = Net::HTTP.get_response URI("http://localhost:#{@port}/nonexistent")
+		assert_equal '404', response.code
+		assert_includes response.body, 'Not Found'
+	end
+
+	def test_query_parameters
+		code = <<~AIR
+			Server {
+				port;
+				new { port = #{@port};
+					./port = port
+				}
+			}
+
+			Web_App | Server {
+				get://search {;
+					"Query: |request.query|"
+				}
+			}
+
+			app = Web_App()
+		AIR
+
+		interpreter = Air::Interpreter.new Air.parse(code), Air::Global.with_standard_library
+		server_instance = interpreter.output
+
+		routes = interpreter.collect_routes_from_instance server_instance
+		@server_runner = Air::Server_Runner.new server_instance, interpreter, routes
+		@server_runner.start
+
+		sleep 0.5
+
+		response = Net::HTTP.get_response URI("http://localhost:#{@port}/search?q=test&page=1")
+		assert_equal '200', response.code
+		# The response should contain the query params
+		assert_includes response.body, 'q'
+	end
+
+	def test_post_route
+		code = <<~AIR
+			Server {
+				port;
+				new { port = #{@port};
+					./port = port
+				}
+			}
+
+			Web_App | Server {
+				post://submit {;
+					"Form submitted"
+				}
+			}
+
+			app = Web_App()
+		AIR
+
+		interpreter = Air::Interpreter.new Air.parse(code), Air::Global.with_standard_library
+		server_instance = interpreter.output
+
+		routes = interpreter.collect_routes_from_instance server_instance
+		@server_runner = Air::Server_Runner.new server_instance, interpreter, routes
+		@server_runner.start
+
+		sleep 0.5
+
+		uri = URI("http://localhost:#{@port}/submit")
+		response = Net::HTTP.post_form uri, {}
+		assert_equal '200', response.code
+		assert_equal 'Form submitted', response.body
+	end
+
+	def test_multiple_servers_with_different_routes
+		port_a = @port
+		port_b = @port + 1
+
+		code = <<~AIR
+			Server {
+				port;
+				new { port;
+					./port = port
+				}
+			}
+
+			Server_A | Server {
+				get://a {;
+					"Response from Server A"
+				}
+			}
+
+			Server_B | Server {
+				get://b {;
+					"Response from Server B"
+				}
+			}
+
+			a = Server_A(#{port_a})
+			b = Server_B(#{port_b})
+		AIR
+
+		interpreter = Air::Interpreter.new Air.parse(code), Air::Global.with_standard_library
+		interpreter.output
+
+		# Collect routes for each server
+		server_a_type = interpreter.stack.first['Server_A']
+		server_b_type = interpreter.stack.first['Server_B']
+
+		# Get server instances from interpreter context
+		a_instance = interpreter.stack.first['a']
+		b_instance = interpreter.stack.first['b']
+
+		routes_a = interpreter.collect_routes_from_instance a_instance
+		routes_b = interpreter.collect_routes_from_instance b_instance
+
+		# Start both servers
+		@server_runner_a = Air::Server_Runner.new a_instance, interpreter, routes_a
+		@server_runner_b = Air::Server_Runner.new b_instance, interpreter, routes_b
+
+		@server_runner_a.start
+		@server_runner_b.start
+
+		sleep 0.5
+
+		# Server A should respond to /a but not /b
+		response_a = Net::HTTP.get_response URI("http://localhost:#{port_a}/a")
+		assert_equal '200', response_a.code
+		assert_equal 'Response from Server A', response_a.body
+
+		response_a_404 = Net::HTTP.get_response URI("http://localhost:#{port_a}/b")
+		assert_equal '404', response_a_404.code
+
+		# Server B should respond to /b but not /a
+		response_b = Net::HTTP.get_response URI("http://localhost:#{port_b}/b")
+		assert_equal '200', response_b.code
+		assert_equal 'Response from Server B', response_b.body
+
+		response_b_404 = Net::HTTP.get_response URI("http://localhost:#{port_b}/a")
+		assert_equal '404', response_b_404.code
+
+		# Cleanup
+		@server_runner_a.stop
+		@server_runner_b.stop
+		@server_runner = nil # So teardown doesn't try to stop it again
+	end
+end

--- a/test/samples/multiple_servers.air
+++ b/test/samples/multiple_servers.air
@@ -1,0 +1,20 @@
+Server {
+    port;
+    new { port = 80;
+        ./port = port
+    }
+}
+
+Server_A | Server {
+  get://a {; "From Server A" }
+}
+
+Server_B | Server {
+  get://b {; "From Server B" }
+}
+
+a = Server_A(8080)
+b = Server_B(8081)
+
+#serve_http a
+#serve_http b

--- a/test/samples/server.air
+++ b/test/samples/server.air
@@ -1,0 +1,15 @@
+Server {
+    port;
+    new { port = 80;
+        ./port = port
+    }
+}
+
+Web_App | Server {
+    get://users/:user_id/posts/:post_id { user_id, post_id;
+        "User |user_id| Post |post_id|"
+    }
+}
+
+app = Web_App()
+#serve_http app

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -1,0 +1,228 @@
+require 'minitest/autorun'
+require_relative '../lib/air'
+require_relative 'base_test'
+require 'net/http'
+require 'uri'
+
+class Server_Test < Base_Test
+	def test_server_instance_creation
+		code = <<~AIR
+		    Server {
+		    	port;
+		    	new { port = 3000;
+		    		./port = port
+		    	}
+		    }
+
+		    server = Server()
+		AIR
+
+		result = Air.interp code
+		assert_instance_of Air::Instance, result
+		assert_equal 3000, result[:port]
+	end
+
+	def test_web_app_with_server_composition
+		code = <<~AIR
+		    Server {
+		    	port;
+		    	new { port = 3001;
+		    		./port = port
+		    	}
+		    }
+
+		    Web_App | Server {
+		    	get:// {;
+		    		"Hello World"
+		    	}
+		    }
+
+		    app = Web_App()
+		AIR
+
+		result = Air.interp code
+		assert_instance_of Air::Instance, result
+		assert_equal 3001, result[:port]
+	end
+
+	def test_route_defined_in_server_type
+		code = <<~AIR
+		    Server {
+		    	port;
+		    	new { port = 3002;
+		    		./port = port
+		    	}
+		    }
+
+		    Web_App | Server {
+		    	get://hello {;
+		    		"Hi there!"
+		    	}
+
+		    	get://users/:id { id;
+		    		"User: |id|"
+		    	}
+		    }
+
+		    app = Web_App()
+		AIR
+
+		interpreter = Air::Interpreter.new Air.parse(code), Air::Global.with_standard_library
+		result      = interpreter.output
+
+		assert_instance_of Air::Instance, result
+
+		# Check that routes were registered
+		assert_equal 2, interpreter.context.routes.count
+	end
+
+	def test_server_runner_initialization
+		code = <<~AIR
+		    Server {
+		    	port;
+		    	new { port = 8888;
+		    		./port = port
+		    	}
+		    }
+		    app = Server()
+		AIR
+
+		interpreter     = Air::Interpreter.new Air.parse(code), Air::Global.with_standard_library
+		server_instance = interpreter.output
+
+		server_runner = Air::Server_Runner.new server_instance, interpreter
+
+		assert_equal 8888, server_runner.port
+		assert_equal server_instance, server_runner.server_instance
+		assert_equal interpreter, server_runner.interpreter
+	end
+
+	def test_route_collection
+		code = <<~AIR
+		    Server {
+		    	port;
+		    	new { port = 3003;
+		    		./port = port
+		    	}
+		    }
+
+		    Web_App | Server {
+		    	get:// {;
+		    		"Home"
+		    	}
+
+		    	post://submit {;
+		    		"Submitted"
+		    	}
+		    }
+
+		    app = Web_App()
+		AIR
+
+		interpreter     = Air::Interpreter.new Air.parse(code), Air::Global.with_standard_library
+		server_instance = interpreter.output
+
+		server_runner = Air::Server_Runner.new server_instance, interpreter
+		routes        = server_runner.interpreter.context.routes
+
+		assert_equal 2, routes.count
+	end
+
+	def test_route_matching
+		code = <<~AIR
+		    Server {
+		    	port;
+		    	new { port = 3004;
+		    		./port = port
+		    	}
+		    }
+
+		    Web_App | Server {
+		    	get://users/:id { id;
+		    		"User |id|"
+		    	}
+
+		    	get://posts/:post_id/comments/:comment_id { post_id, comment_id;
+		    		"Post |post_id| Comment |comment_id|"
+		    	}
+		    }
+
+		    app = Web_App()
+		AIR
+
+		interpreter     = Air::Interpreter.new Air.parse(code), Air::Global.with_standard_library
+		server_instance = interpreter.output
+
+		server_runner = Air::Server_Runner.new server_instance, interpreter
+		routes        = server_runner.interpreter.context.routes
+
+		# Test matching simple parameterized route
+		matched = server_runner.match_route 'get', ['users', '123'], routes
+		assert matched
+		assert_equal 'get', matched.http_method.value
+
+		# Test matching nested parameterized route
+		matched = server_runner.match_route 'get', ['posts', '456', 'comments', '789'], routes
+		assert matched
+		assert_equal 'get', matched.http_method.value
+
+		# Test non-matching route
+		matched = server_runner.match_route 'post', ['users', '123'], routes
+		assert_nil matched
+	end
+
+	def test_url_param_extraction
+		code = <<~AIR
+		    Server {
+		    	port;
+		    	new { port = 3005;
+		    		./port = port
+		    	}
+		    }
+
+		    Web_App | Server {
+		    	get://users/:user_id/posts/:post_id { user_id, post_id;
+		    		"User |user_id| Post |post_id|"
+		    	}
+		    }
+
+		    app = Web_App()
+		AIR
+
+		interpreter     = Air::Interpreter.new Air.parse(code), Air::Global.with_standard_library
+		server_instance = interpreter.output
+
+		server_runner = Air::Server_Runner.new server_instance, interpreter
+		routes        = server_runner.interpreter.context.routes
+		route         = routes.values.first
+
+		path_parts = ['users', '42', 'posts', '99']
+		url_params = server_runner.extract_url_params path_parts, route
+
+		assert_equal '42', url_params['user_id']
+		assert_equal '99', url_params['post_id']
+	end
+
+	def test_query_string_parsing
+		server_instance = Air::Instance.new 'Server'
+		interpreter     = Air::Interpreter.new [], Air::Global.new
+		server_runner   = Air::Server_Runner.new server_instance, interpreter
+
+		query_params = server_runner.parse_query_string 'name=John&age=30&city=NYC'
+
+		assert_equal 'John', query_params['name']
+		assert_equal '30', query_params['age']
+		assert_equal 'NYC', query_params['city']
+	end
+
+	def test_query_string_with_url_encoding
+		server_instance = Air::Instance.new 'Server'
+		interpreter     = Air::Interpreter.new [], Air::Global.new
+		server_runner   = Air::Server_Runner.new server_instance, interpreter
+
+		query_params = server_runner.parse_query_string 'message=Hello%20World&special=%21%40%23'
+
+		assert_equal 'Hello World', query_params['message']
+		assert_equal '!@#', query_params['special']
+	end
+end


### PR DESCRIPTION
Enable multiple server instances to run simultaneously in a single Air file, each with their own isolated route collections.

Previously, all routes were stored globally in context.routes, causing all server instances to share the same routes. Now routes are stored per-type in the Type's @routes hash and collected from an instance's composed types when starting a server.

Changes:
- Add @routes attribute to Type class for per-type route storage
- Initialize @routes in Server class constructor
- Modify interp_route to store routes in enclosing Type's @routes hash
- Add collect_routes_from_instance method to gather routes from type hierarchy
- Update Server_Runner to accept and use instance-specific routes
- Update #serve_http directive to collect and pass routes to Server_Runner
- Add test_multiple_servers_with_different_routes test case
- Update existing E2E tests to use new route collection pattern

Result:
Multiple servers can now be defined and started with separate routes. Each server only serves its own routes and returns 404 for others' routes.