### PR TITLE
Add loop control flow operators skip and stop

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,8 @@ Ore is an educational programming language for web development, implemented in R
 - Dot notation for accessing nested structures and scopes (./, ../, .../)
 - First-class functions and classes
 - Built-in web server support with routing
-- Backtick (\`) character for comments (no space after backtick: "\`comment" not "\` comment")
+- When writing .ore source, use backtick (\`) character for comments (no space after backtick: "\`comment" not "\` comment")
+- When writing .rb source, use # for comments
 
 ## Common Commands
 
@@ -74,7 +75,8 @@ The AST is executed to produce output:
 Used by both compiler and runtime:
 
 - `constants.rb` - Language constants, operators, precedence table, reserved words
-- `helpers.rb` - Utility functions for identifier classification (constant_identifier?, type_identifier?, member_identifier?)
+-
+`helpers.rb` - Utility functions for identifier classification (constant_identifier?, type_identifier?, member_identifier?)
 
 ### Entry Point
 

--- a/lib/compiler/lexer.rb
+++ b/lib/compiler/lexer.rb
@@ -252,7 +252,7 @@ module Ore
 					elsif identifier? || %w(_).include?(curr)
 						it.value = lex_identifier
 						it.type  = Ore.type_of_identifier it.value
-						if %w(for).include?(it.value)
+						if %w(for skip stop).include?(it.value)
 							it.type = :operator
 						end
 

--- a/lib/shared/constants.rb
+++ b/lib/shared/constants.rb
@@ -57,6 +57,7 @@ module Ore
 		unless until
 		true false nil
 		and or return
+		skip stop
 	)
 
 	PRECEDENCES = {

--- a/test/interpreter_test.rb
+++ b/test/interpreter_test.rb
@@ -1198,4 +1198,142 @@ class Interpreter_Test < Base_Test
 		assert_equal [2, 3, 4, 5], out.values[2].values
 		assert_equal [1, 2, 3, 4], out.values[3].values
 	end
+
+	def test_for_loop_skip
+		out = Ore.interp "
+		result = []
+		for [1, 2, 3, 4, 5]
+			if it == 3
+				skip
+			end
+			result << it
+		end
+		result"
+		assert_equal [1, 2, 4, 5], out.values
+	end
+
+	def test_for_loop_stop
+		out = Ore.interp "
+		result = []
+		for [1, 2, 3, 4, 5]
+			if it == 3
+				stop
+			end
+			result << it
+		end
+		result"
+		assert_equal [1, 2], out.values
+	end
+
+	def test_for_loop_skip_with_index
+		out = Ore.interp "
+		result = []
+		for ['a', 'b', 'c', 'd']
+			if at == 1 or at == 2
+				skip
+			end
+			result << it
+		end
+		result"
+		assert_equal ['a', 'd'], out.values
+	end
+
+	def test_for_loop_stop_with_index
+		out = Ore.interp "
+		result = []
+		for ['a', 'b', 'c', 'd']
+			if at == 2
+				stop
+			end
+			result << it
+		end
+		result"
+		assert_equal ['a', 'b'], out.values
+	end
+
+	def test_nested_for_loop_stop
+		out = Ore.interp "
+		result = []
+
+		for 0..10
+			skip if it == 4
+
+			if it % 2 == 0
+				result << 'START |it|'
+				for 0..10
+					result << it
+					stop if it == 2
+				end
+				result << 'STOP |it|'
+			end
+
+			if it == 6
+				stop
+			end
+		end
+
+		result
+		"
+		assert_equal ["START 0", 0, 1, 2, "STOP 0", "START 2", 0, 1, 2, "STOP 2", "START 6", 0, 1, 2, "STOP 6"], out.values
+	end
+
+	def test_while_loop_skip
+		out = Ore.interp "
+		result = []
+		x = 0
+		while x < 5
+			x += 1
+			if x == 3
+				skip
+			end
+			result << x
+		end
+		result"
+		assert_equal [1, 2, 4, 5], out.values
+	end
+
+	def test_while_loop_stop
+		out = Ore.interp "
+		result = []
+		x = 0
+		while x < 10
+			x += 1
+			if x == 4
+				stop
+			end
+			result << x
+		end
+		result"
+		assert_equal [1, 2, 3], out.values
+	end
+
+	def test_until_loop_skip
+		out = Ore.interp "
+		result = []
+		x = 0
+		until x >= 5
+			x += 1
+			if x == 2 or x == 4
+				skip
+			end
+			result << x
+		end
+		result"
+		assert_equal [1, 3, 5], out.values
+	end
+
+	def test_until_loop_stop
+		out = Ore.interp "
+		result = []
+		x = 0
+		until x >= 10
+			x += 1
+			if x == 3
+				stop
+			end
+			result << x
+		end
+		result"
+		assert_equal [1, 2], out.values
+	end
 end

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -282,8 +282,8 @@ class Lexer_Test < Base_Test
 		assert_equal [
 			             :operator, :delimiter, :number, :delimiter, :number, :delimiter, :number, :delimiter, :number, :delimiter, :number, :delimiter, :delimiter,
 			             :identifier, :identifier, :identifier, :identifier, :delimiter, :delimiter, :operator, :number, :delimiter,
-			             :identifier, :delimiter,
-			             :identifier, :delimiter,
+			             :operator, :delimiter,
+			             :operator, :delimiter,
 			             :identifier
 		             ], out.map(&:type)
 	end
@@ -303,6 +303,14 @@ class Lexer_Test < Base_Test
 
 	def test_return_is_an_operator
 		out = Ore.lex 'return 1 + 2'
+		assert_equal :operator, out.first.type
+	end
+
+	def test_skip_and_stop_are_operators
+		out = Ore.lex 'skip'
+		assert_equal :operator, out.first.type
+
+		out = Ore.lex 'stop'
 		assert_equal :operator, out.first.type
 	end
 

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -805,4 +805,12 @@ class Parser_Test < Base_Test
 
 		assert_equal 5, out.first.expressions.count
 	end
+
+	def test_skip_and_stop_are_operators
+		out = Ore.parse 'skip'
+		assert_instance_of Ore::Operator_Expr, out.first
+
+		out = Ore.parse 'stop'
+		assert_instance_of Ore::Operator_Expr, out.first
+	end
 end


### PR DESCRIPTION
- `skip` - Exits the current iteration and continues with the next one (similar to 'next' in Ruby)
- `stop` - Completely exits the loop (similar to 'break' in most languages)
- Lexer: Added skip/stop to operator tokenization
- Constants: Added to RESERVED words list
- Interpreter implementation uses Ruby's catch/throw mechanism
  - throw :skip caught at iteration level
  - throw :stop caught at loop level
  - Nested catch blocks ensure proper scoping
- Added test coverage
- Improved CLAUDE.md