### PR TITLE
Add sibling_scope manipulation operators

### DIFF
--- a/lib/compiler/parser.rb
+++ b/lib/compiler/parser.rb
@@ -336,10 +336,7 @@ module Ore
 			start = curr_lexeme
 
 			expr = Ore::Identifier_Expr.new
-			if curr? UNPACK_PREFIX
-				expr.unpack = true
-				eat UNPACK_PREFIX
-			elsif curr? DIRECTIVE_PREFIX
+			if curr? DIRECTIVE_PREFIX
 				expr.directive = true
 				eat DIRECTIVE_PREFIX
 			elsif curr? SCOPE_OPERATORS

--- a/lib/runtime/errors.rb
+++ b/lib/runtime/errors.rb
@@ -61,6 +61,18 @@ module Ore
 		end
 	end
 
+	class Invalid_Unpack_Infix_Operator < Error
+		def error_message
+			"Invalid operator '#{expression.operator}' in unpack operation - expected += or -="
+		end
+	end
+
+	class Invalid_Unpack_Infix_Right_Operand < Error
+		def error_message
+			"Invalid right operand '#{expression.right}' in unpack operation - expected a Scope"
+		end
+	end
+
 	class Unhandled_Prefix < Error
 		def error_message
 			"Unhandled prefix operator '#{expression.operator}'"

--- a/lib/runtime/scope.rb
+++ b/lib/runtime/scope.rb
@@ -15,7 +15,7 @@ module Ore
 			key_str = key&.to_s
 
 			# todo: Currently there is no clear rule on multiple unpacks. :double_unpack
-			@sibling_scopes.each do |sibling|
+			@sibling_scopes.reverse_each do |sibling|
 				return sibling[key_str] if sibling.has? key_str
 			end
 

--- a/lib/shared/constants.rb
+++ b/lib/shared/constants.rb
@@ -8,7 +8,7 @@ module Ore
 	INTERPOLATE_CHAR           = '|'
 	COMMENT_CHAR               = '`'
 	COMMENT_MULTILINE_CHAR     = '```'
-	PREFIX                     = %w(! - + ~ $ @ # ? & ^ not return)
+	PREFIX                     = %w(! - + ~ $ # ? & ^ not return)
 	INFIX                      = %w(
 		+ - ^ * ** / % ~ == === ? . .?
 		= : ||= &&= **= <<= >>= += -= *= |= /= %= &= ^=

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -709,14 +709,6 @@ class Parser_Test < Base_Test
 	end
 
 	def test_unpack_prefix
-		out = Ore.parse '@count'
-		assert out.first.unpack
-		assert_kind_of Ore::Identifier_Expr, out.first
-
-		out = Ore.parse 'count'
-		refute out.first.unpack
-		assert_kind_of Ore::Identifier_Expr, out.first
-
 		out = Ore.parse 'funk { @with; }'
 		assert_kind_of Ore::Param_Expr, out.first.expressions.first
 		assert out.first.expressions.first.unpack


### PR DESCRIPTION
I quickly changed my mind on allowing `@instance` prefix in any scope. It didn't provide enough control to the user.

- `@` is no longer a standalone prefix as it used to be
- Add to sibling scopes with `@ += some_scope`
- Remove from sibling scopes with `@ -= some_scope`