### PR TITLE
Refactor Interpreter to be stateless

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -63,9 +63,9 @@ Source code is tokenized and parsed into an Abstract Syntax Tree (AST):
 
 The AST is executed to produce output:
 
-- `interpreter.rb` - Traverses and executes the AST
+- `interpreter.rb` - Traverses and executes the AST, is stateless
 - `scope.rb` - Manages variable scoping and declarations (Global, Type, Instance, Func, Route, Return scopes)
-- `context.rb` - Tracks execution state (routes, servers, loaded files)
+- `runtime.rb` - Tracks execution state (declarations, routes, servers, loaded files)
 - `types.rb` - Runtime type definitions (includes Request, Response, Server classes)
 - `errors.rb` - Runtime error definitions
 - `server_runner.rb` - HTTP server implementation using WEBrick (handles routing, URL params, query strings)
@@ -76,6 +76,7 @@ Used by both compiler and runtime:
 
 - `constants.rb` - Language constants, operators, precedence table, reserved words
 -
+
 `helpers.rb` - Utility functions for identifier classification (constant_identifier?, type_identifier?, member_identifier?)
 
 ### Entry Point
@@ -102,7 +103,8 @@ Ore uses a sophisticated scope hierarchy:
 - **Html_Element** - HTML element scopes (tracks `@expressions`, `@attributes`, `@types`)
 - **Return** - Return value wrapper (tracks `@value`)
 
-Each scope can have **sibling scopes** - additional scopes checked first during identifier lookup, used by the unpack feature.
+Each scope can have **sibling scopes
+** - additional scopes checked first during identifier lookup, used by the unpack feature.
 
 Scope operators in the language:
 
@@ -148,6 +150,7 @@ x = island_member  `Access members directly
 ```
 
 **Implementation details:**
+
 - `@param` in function signature automatically unpacks parameter into sibling scope
 - `@ += instance` and `@ -= instance` provide manual control in any scope
 - Sibling scopes are checked first during identifier lookup (before current scope declarations)
@@ -169,6 +172,7 @@ dict.values  `Get all values
 ```
 
 **Features:**
+
 - Symbol, string, or identifier keys
 - Subscript access via `dict[key]`
 - Methods: `keys`, `values`
@@ -193,6 +197,7 @@ end
 ```
 
 **Intrinsic variables:**
+
 - `it` - Current iteration value
 - `at` - Current iteration index
 

--- a/lib/readme.md
+++ b/lib/readme.md
@@ -15,7 +15,7 @@ This [`lib`](/lib) folder contains the implementation of Ore in Ruby. The codeba
 - [`errors.rb`](runtime/errors.rb) - Runtime error definitions
 - [`scope.rb`](runtime/scope.rb) - Scoping and variable management
 - [`types.rb`](runtime/types.rb) - Runtime type definitions
-- [`execution_context.rb`](runtime/context.rb) - Execution state management
+- [`runtime.rb`](runtime/runtime.rb) - Execution state management
 
 **Orchestration**
 

--- a/lib/runtime/error_formatter.rb
+++ b/lib/runtime/error_formatter.rb
@@ -28,12 +28,12 @@ module Ore
 	end
 
 	class Error_Formatter
-		attr_reader :error, :expression, :context
+		attr_reader :error, :expression, :runtime
 
-		def initialize error, context
+		def initialize error, runtime
 			@error      = error
 			@expression = error.expression
-			@context    = context
+			@runtime    = runtime
 		end
 
 		def format
@@ -57,7 +57,7 @@ module Ore
 		end
 
 		def source_available?
-			context && location_available?
+			runtime && location_available?
 		end
 
 		def location_line
@@ -71,13 +71,13 @@ module Ore
 		end
 
 		def source_snippet
-			return nil unless context
+			return nil unless runtime
 
 			l0, c0, l1, c1 = get_location_coords
 			return nil unless l0
 
 			source_file = get_source_file
-			lines       = context.source_files[source_file] || []
+			lines       = runtime.source_files[source_file] || []
 			return nil if lines.empty?
 
 			start_line = [l0 - 1, 1].max

--- a/lib/runtime/errors.rb
+++ b/lib/runtime/errors.rb
@@ -2,11 +2,11 @@ require_relative 'error_formatter'
 
 module Ore
 	class Error < StandardError
-		attr_accessor :expression, :context
+		attr_accessor :expression, :runtime
 
-		def initialize expression = nil, context = nil
+		def initialize expression = nil, runtime = nil
 			@expression = expression
-			@context    = context
+			@runtime    = runtime
 			super format_error
 		end
 
@@ -15,7 +15,7 @@ module Ore
 		end
 
 		def format_error
-			Error_Formatter.new(self, context).format
+			Error_Formatter.new(self, runtime).format
 		end
 	end
 

--- a/lib/runtime/runtime.rb
+++ b/lib/runtime/runtime.rb
@@ -1,26 +1,53 @@
 module Ore
-	class Context
-		attr_accessor :routes, :servers, :loaded_files, :source_files
+	class Runtime
+		attr_accessor :stack, :routes, :servers, :loaded_files, :source_files
 
-		def initialize
-			@routes       = {}
+		def initialize global_scope = nil
+			@stack        = [global_scope || Ore::Global.new]
 			@servers      = []
+			@routes       = {} # {route: Ore::Route}
 			@loaded_files = {} # {filename: expressions}
 			@source_files = {} # {filepath: source_code} for error reporting
 		end
 
+		def push_scope scope
+			scope ||= stack.last
+
+			stack << scope
+		end
+
+		def pop_scope
+			if stack.length == 1
+				stack.last
+			else
+				stack.pop
+			end
+		end
+
+		def push_then_pop scope
+			# todo: Proper error
+			raise "Attempting to push `nil` value as scope" if scope == nil
+
+			push_scope scope
+			if block_given?
+				yield scope
+			end
+			pop_scope
+		end
+
 		def register_source filepath, source_code
 			resolved                = filepath ? File.expand_path(filepath) : '<inline>'
-			@source_files[resolved] = source_code.lines.map(&:chomp) # Store lines, not string
+			@source_files[resolved] = source_code.lines.map(&:chomp)
 		end
 
 		def load_file filepath, into_scope
 			resolved_path = File.expand_path filepath
+			push_scope into_scope
 
 			unless loaded_files[resolved_path]
 				code = File.read resolved_path
 				register_source resolved_path, code
-				
+
 				lexemes                     = Ore::Lexer.new(code, filepath: resolved_path).output
 				expressions                 = Ore::Parser.new(lexemes, source_file: resolved_path).output
 				loaded_files[resolved_path] = expressions
@@ -28,8 +55,11 @@ module Ore
 
 			# Always interpret into the target scope (allows reuse in different scopes)
 			expressions      = loaded_files[resolved_path]
-			temp_interpreter = Ore::Interpreter.new expressions, into_scope, self
-			temp_interpreter.output
+			temp_interpreter = Ore::Interpreter.new expressions, self
+			output           = temp_interpreter.output
+
+			pop_scope
+			output
 		end
 	end
 end

--- a/lib/runtime/scope.rb
+++ b/lib/runtime/scope.rb
@@ -60,11 +60,11 @@ module Ore
 			load_file STANDARD_LIBRARY_PATH
 		end
 
-		# Convenience method for loading files into this scope without a context
+		# Convenience method for loading files into this scope without a runtime
 		# Creates a temporary Context to handle file loading
 		def load_file filepath
-			temp_context = Ore::Context.new
-			temp_context.load_file filepath, self
+			temp_runtime = Ore::Runtime.new
+			temp_runtime.load_file filepath, self
 			self
 		end
 	end

--- a/test/e2e_server_test.rb
+++ b/test/e2e_server_test.rb
@@ -40,7 +40,7 @@ class E2E_Server_Test < Minitest::Test
 		ORE
 
 		# Start server in background
-		interpreter     = Ore::Interpreter.new Ore.parse(code), Ore::Global.with_standard_library
+		interpreter     = Ore::Interpreter.new Ore.parse(code)
 		server_instance = interpreter.output
 
 		routes         = interpreter.collect_routes_from_instance server_instance
@@ -84,7 +84,7 @@ class E2E_Server_Test < Minitest::Test
 		    app = Web_App()
 		ORE
 
-		interpreter     = Ore::Interpreter.new Ore.parse(code), Ore::Global.with_standard_library
+		interpreter     = Ore::Interpreter.new Ore.parse(code)
 		server_instance = interpreter.output
 
 		routes         = interpreter.collect_routes_from_instance server_instance
@@ -117,7 +117,7 @@ class E2E_Server_Test < Minitest::Test
 		    app = Web_App()
 		ORE
 
-		interpreter     = Ore::Interpreter.new Ore.parse(code), Ore::Global.with_standard_library
+		interpreter     = Ore::Interpreter.new Ore.parse(code)
 		server_instance = interpreter.output
 
 		routes         = interpreter.collect_routes_from_instance server_instance
@@ -160,16 +160,16 @@ class E2E_Server_Test < Minitest::Test
 		    b = Server_B(#{port_b})
 		ORE
 
-		interpreter = Ore::Interpreter.new Ore.parse(code), Ore::Global.with_standard_library
+		interpreter = Ore::Interpreter.new Ore.parse(code)
 		interpreter.output
 
 		# Collect routes for each server
-		server_a_type = interpreter.stack.first['Server_A']
-		server_b_type = interpreter.stack.first['Server_B']
+		server_a_type = interpreter.runtime.stack.first['Server_A']
+		server_b_type = interpreter.runtime.stack.first['Server_B']
 
-		# Get server instances from interpreter context
-		a_instance = interpreter.stack.first['a']
-		b_instance = interpreter.stack.first['b']
+		# Get server instances from interpreter runtime
+		a_instance = interpreter.runtime.stack.first['a']
+		b_instance = interpreter.runtime.stack.first['b']
 
 		routes_a = interpreter.collect_routes_from_instance a_instance
 		routes_b = interpreter.collect_routes_from_instance b_instance

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -67,13 +67,13 @@ class Server_Test < Base_Test
 		    app = Web_App()
 		ORE
 
-		interpreter = Ore::Interpreter.new Ore.parse(code), Ore::Global.with_standard_library
+		interpreter = Ore::Interpreter.new Ore.parse(code)
 		result      = interpreter.output
 
 		assert_instance_of Ore::Instance, result
 
 		# Check that routes were registered
-		assert_equal 2, interpreter.context.routes.count
+		assert_equal 2, interpreter.runtime.routes.count
 	end
 
 	def test_server_runner_initialization
@@ -87,7 +87,7 @@ class Server_Test < Base_Test
 		    app = Server()
 		ORE
 
-		interpreter     = Ore::Interpreter.new Ore.parse(code), Ore::Global.with_standard_library
+		interpreter     = Ore::Interpreter.new Ore.parse(code)
 		server_instance = interpreter.output
 
 		server_runner = Ore::Server_Runner.new server_instance, interpreter
@@ -119,11 +119,11 @@ class Server_Test < Base_Test
 		    app = Web_App()
 		ORE
 
-		interpreter     = Ore::Interpreter.new Ore.parse(code), Ore::Global.with_standard_library
+		interpreter     = Ore::Interpreter.new Ore.parse(code)
 		server_instance = interpreter.output
 
 		server_runner = Ore::Server_Runner.new server_instance, interpreter
-		routes        = server_runner.interpreter.context.routes
+		routes        = server_runner.interpreter.runtime.routes
 
 		assert_equal 2, routes.count
 	end
@@ -150,11 +150,11 @@ class Server_Test < Base_Test
 		    app = Web_App()
 		ORE
 
-		interpreter     = Ore::Interpreter.new Ore.parse(code), Ore::Global.with_standard_library
+		interpreter     = Ore::Interpreter.new Ore.parse(code)
 		server_instance = interpreter.output
 
 		server_runner = Ore::Server_Runner.new server_instance, interpreter
-		routes        = server_runner.interpreter.context.routes
+		routes        = server_runner.interpreter.runtime.routes
 
 		# Test matching simple parameterized route
 		matched = server_runner.match_route 'get', ['users', '123'], routes
@@ -189,11 +189,11 @@ class Server_Test < Base_Test
 		    app = Web_App()
 		ORE
 
-		interpreter     = Ore::Interpreter.new Ore.parse(code), Ore::Global.with_standard_library
+		interpreter     = Ore::Interpreter.new Ore.parse(code)
 		server_instance = interpreter.output
 
 		server_runner = Ore::Server_Runner.new server_instance, interpreter
-		routes        = server_runner.interpreter.context.routes
+		routes        = server_runner.interpreter.runtime.routes
 		route         = routes.values.first
 
 		path_parts = ['users', '42', 'posts', '99']
@@ -205,7 +205,7 @@ class Server_Test < Base_Test
 
 	def test_query_string_parsing
 		server_instance = Ore::Instance.new 'Server'
-		interpreter     = Ore::Interpreter.new [], Ore::Global.new
+		interpreter     = Ore::Interpreter.new []
 		server_runner   = Ore::Server_Runner.new server_instance, interpreter
 
 		query_params = server_runner.parse_query_string 'name=John&age=30&city=NYC'
@@ -217,7 +217,7 @@ class Server_Test < Base_Test
 
 	def test_query_string_with_url_encoding
 		server_instance = Ore::Instance.new 'Server'
-		interpreter     = Ore::Interpreter.new [], Ore::Global.new
+		interpreter     = Ore::Interpreter.new []
 		server_runner   = Ore::Server_Runner.new server_instance, interpreter
 
 		query_params = server_runner.parse_query_string 'message=Hello%20World&special=%21%40%23'


### PR DESCRIPTION
- Rename Context to Runtime
- Replaced all `context` identifiers with `runtime` in code
- Move @stack from Interpreter to Runtime
- Update CLAUDE.md and readme.md