### PR TITLE
Reimplement static declarations

### DIFF
--- a/lib/runtime/error_formatter.rb
+++ b/lib/runtime/error_formatter.rb
@@ -77,9 +77,8 @@ module Ore
 		end
 
 		def location_line
-
 			# todo bug: Does not display source code properly
-			if expression.instance_of?(Ore::Expression) && expression.l0
+			if expression.is_a?(Ore::Expression) && expression.l0
 				"#{expression.source_file}:#{expression.l0}:#{expression.c0}"
 			else
 				# todo: How do I get the source string here?
@@ -149,7 +148,7 @@ module Ore
 		private
 
 		def get_location_coords
-			if expression.instance_of?(Ore::Expression) && expression.l0
+			if expression.is_a?(Ore::Expression) && expression.l0
 				[expression.l0, expression.c0, expression.l1 || expression.l0, expression.c1 || expression.c0]
 			else
 				[nil, nil, nil, nil]

--- a/lib/runtime/errors.rb
+++ b/lib/runtime/errors.rb
@@ -90,6 +90,14 @@ module Ore
 	class Cannot_Call_Private_Static_Type_Member < Error
 	end
 
+	class Invalid_Intrinsic_Directive_Declaration < Error
+		# #intrinsic directive only supports function and variable declarations in the body of a Type declaration
+	end
+
+	class Invalid_Static_Directive_Declaration < Error
+		# #static directive only supports function and variable declarations in the body of a Type declaration
+	end
+
 	class Unterminated_String_Literal < Error
 	end
 

--- a/lib/runtime/scopes.rb
+++ b/lib/runtime/scopes.rb
@@ -69,12 +69,16 @@ module Ore
 		end
 	end
 
+	class Global < Scope
+	end
+
 	class Type < Scope
-		attr_accessor :expressions, :types, :routes
+		attr_accessor :expressions, :types, :routes, :static_declarations
 
 		def initialize name = nil
 			super name
-			@types = [name].compact
+			@types               = Set[name]
+			@static_declarations = Set.new
 		end
 	end
 
@@ -84,15 +88,12 @@ module Ore
 		end
 	end
 
-	class Global < Scope
+	class Func < Scope
+		attr_accessor :expressions, :intrinsic, :static
 	end
 
 	class Html_Element < Scope
 		attr_accessor :expressions, :attributes, :types
-	end
-
-	class Func < Scope
-		attr_accessor :expressions, :intrinsic
 	end
 
 	class Route < Func

--- a/lib/shared/helpers.rb
+++ b/lib/shared/helpers.rb
@@ -53,36 +53,21 @@ module Helpers
 		leading_underscores = ident.match(/^_*/)[0].length
 
 		case leading_underscores
-		when 0, 2
+		when 0
 			:public
-		when 1, 3
-			:private
 		else
-			:public # 4+ underscores
+			:private
 		end
 	end
 
-	# Rules:
-	# _ident   = instance
-	# __ident  = static
-	# ___ident = static
-	# IDENT    = static
-	# else       instance
-	def binding_of_ident ident
-		# note: Constants and Type declarations are considered static
-		return :static if %i(IDENTIFIER Identifier).include? type_of_identifier(ident)
+	def binding_of_ident scope, ident
+		ident = ident&.to_s
+		return :static if %i(IDENTIFIER Identifier).include? type_of_identifier ident
 
-		leading_underscores = ident.match(/^_*/)[0].length
-
-		case leading_underscores
-		when 2, 3
+		if scope.is_a?(Ore::Type) && scope.static_declarations&.include?(ident)
 			:static
 		else
 			:instance
 		end
-	end
-
-	def binding_and_privacy ident
-		return binding_of_ident(ident), privacy_of_ident(ident)
 	end
 end


### PR DESCRIPTION
No longer identifying static declarations via double underscore prefix, but instead using a #static directive.

- Replace underscore-based static binding with #static directive
- Add @static attr to Ore::Func
- Add @static_declarations Set to Ore::Type to track static members
- Update binding_of_ident to check scope.static_declarations instead of underscores
- Remove binding_and_privacy helper (split into separate calls)
- Add #static directive handler in interpreter
- Add Invalid_Static_Directive_Declaration error
- Add Invalid_Intrinsic_Directive_Declaration error
- Change Type#types from Array to Set
- Improve parser copy_location to accept expr or lexeme
- Remove binding attr from Identifier_Expr (computed at runtime now)
- Add tests for static/instance binding and privacy