### PR TITLE
Reimplement scope operators with static declarations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,6 +31,23 @@ rescue Exception => e
 	raise e
 end
 
+task :lex, [:string] do |_, args|
+	if args[:string].nil? || args[:string].empty?
+		raise ArgumentError, "rake lex expected file arguments `bundle exec rake lex[\"Hello!\"]`"
+	end
+
+	# Rake splits on commas, so rejoin all arguments. I wouldn't do this anywhere else except for this specific task. It helps me to not have to remember to escape commas when I'm lexreting code using this task.
+	full_string = ([args[:string]] + args.extras).join(',')
+	pp Ore.lex(full_string)
+rescue SystemExit
+	# Interrupt exit
+rescue Ore::Error => e
+	$stderr.puts e.message # Prevents Ruby stack trace from polluting Ore error message
+	exit 1
+rescue Exception => e
+	raise e
+end
+
 task :parse, [:string] do |_, args|
 	if args[:string].nil? || args[:string].empty?
 		raise ArgumentError, "rake parse expected file arguments `bundle exec rake parse[\"Hello!\"]`"

--- a/lib/compiler/lexer.rb
+++ b/lib/compiler/lexer.rb
@@ -191,6 +191,11 @@ module Ore
 			it = ::String.new
 			while chars? && symbol? && !%w(' ").include?(curr)
 				it << eat
+
+				# todo: Break on all known operator, not just scope operators
+				if SCOPE_OPERATORS.include? it
+					break
+				end
 			end
 
 			it

--- a/lib/runtime/errors.rb
+++ b/lib/runtime/errors.rb
@@ -72,7 +72,13 @@ module Ore
 	class Out_Of_Tokens < Error
 	end
 
-	class Invalid_Scoped_Identifier < Error
+	class Invalid_Scope_Syntax < Error
+	end
+
+	class Cannot_Use_Instance_Scope_Operator_Outside_Instance < Error
+	end
+
+	class Cannot_Use_Type_Scope_Operator_Outside_Type < Error
 	end
 
 	class Too_Many_Subscript_Expressions < Error

--- a/lib/runtime/scopes.rb
+++ b/lib/runtime/scopes.rb
@@ -80,6 +80,10 @@ module Ore
 			@types               = Set[name]
 			@static_declarations = Set.new
 		end
+
+		def has? identifier
+			super(identifier) || @static_declarations.include?(identifier)
+		end
 	end
 
 	class Instance < Type

--- a/lib/shared/constants.rb
+++ b/lib/shared/constants.rb
@@ -30,7 +30,7 @@ module Ore
 	TYPE_COMPOSITION_OPERATORS = %w(| & ~ ^) # Union, Intersection, Removal, Symmetric Difference
 	ANY_IDENTIFIER             = %i(identifier Identifier IDENTIFIER)
 	GSCOPE                     = :global
-	SCOPE_OPERATORS            = %w(./ ../)
+	SCOPE_OPERATORS            = %w(./ ../ ~/)
 	STARTING_PRECEDENCE        = 0
 	DELIMITERS                 = %W(, ; { } ( ) [ ] \n \r).freeze
 	NEWLINES                   = %W(\r\n \n).freeze

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -85,13 +85,6 @@ class Error_Test < Base_Test
 		end
 	end
 
-	def test_invalid_scoped_identifier
-		# todo: Doesn't display code and location
-		assert_raises Ore::Invalid_Scoped_Identifier do
-			Ore.interp '../'
-		end
-	end
-
 	def test_too_many_subscript_expressions
 		error = assert_raises Ore::Too_Many_Subscript_Expressions do
 			Ore.interp 'arr = [1, 2, 3], arr[0, 1]'

--- a/test/fixtures/static_declarations.ore
+++ b/test/fixtures/static_declarations.ore
@@ -1,0 +1,11 @@
+Person {
+    ../count = 0
+
+    new {;
+        ../count += 1
+    }
+}
+
+Person()
+Person()
+Person.count `=> 2

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -284,9 +284,9 @@ class Parser_Test < Base_Test
 		assert_kind_of Ore::Identifier_Expr, out.first
 		assert_equal './', out.first.scope_operator
 
-		out = Ore.parse '../global_scope'
+		out = Ore.parse '~/global_scope'
 		assert_kind_of Ore::Identifier_Expr, out.first
-		assert_equal '../', out.first.scope_operator
+		assert_equal '~/', out.first.scope_operator
 	end
 
 	def test_functions
@@ -718,11 +718,7 @@ class Parser_Test < Base_Test
 		assert_instance_of Ore::Circumfix_Expr, out.first.collection # note, The iterable becomes an Array in the interpreter.
 		assert_equal '[]', out.first.collection.grouping
 	end
-
-	def test_import_syntax
-		out = Ore.parse 'project_root = ~/'
-	end
-
+	
 	def test_directive_identifier
 		out = Ore.parse '#whatever'
 		refute_instance_of Ore::Directive_Expr, out.first

--- a/test/regression_test.rb
+++ b/test/regression_test.rb
@@ -24,16 +24,6 @@ class Regression_Test < Base_Test
 	end
 
 	def test_dot_slashes_regression
-		invalid_samples = [
-			'./', '../',
-		]
-
-		invalid_samples.each do |sample|
-			assert_raises Ore::Invalid_Scoped_Identifier do
-				Ore.parse sample
-			end
-		end
-
 		ds  = Ore.parse './abc'
 		dds = Ore.parse '../def'
 		assert_kind_of Ore::Identifier_Expr, ds.first
@@ -50,15 +40,15 @@ class Regression_Test < Base_Test
 		assert_equal 123, out
 	end
 
-	def test_look_up_dot_slash_without_dot_slash_regression
-		out = Ore.interp './x = 456
+	def test_look_up_tilde_slash_without_dot_slash_regression
+		out = Ore.interp '~/x = 456
 		x'
 		assert_equal 456, out
 	end
 
-	def test_look_up_dot_slash_with_dot_slash_regression
-		out = Ore.interp './y = 789
-		./y'
+	def test_look_up_tilde_slash_with_dot_slash_regression
+		out = Ore.interp '~/y = 789
+		~/y'
 		assert_equal 789, out
 	end
 
@@ -157,19 +147,16 @@ class Regression_Test < Base_Test
 	end
 
 	def test_identifier_lookup_regression
-		out = Ore.interp "./x = 123, ./x"
-		assert_equal 123, out
-
 		out = Ore.interp "x = 123
 		funk {;
-			./x + 2
+			~/x + 2
 		}
 		funk()"
 		assert_equal 125, out
 
 		out = Ore.interp "y = 0
 		add { amount_to_add = 1;
-			./y + amount_to_add
+			~/y + amount_to_add
 		}
 		(a = add(4))
 


### PR DESCRIPTION
This is a rewrite of scope operator semantics, and implements static declarations using the `../` operator, replacing the `#static` directive.

### Scope Operator Changes

**New semantics:**
- `~/identifier` - Access global scope only
- `./identifier` - Access instance scope only (no global fallback)
- `../identifier` - Access type scope only (for static members)
- `identifier` - Search all scopes from current to global

### Example
```ore
Person {
    ../count = 0

    new {;
        ../count += 1
    }
}

Person()
Person()
Person.count `=> 2
```