### PR TITLE
Add foundation for Databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .zed/
+*.db
 *.DS_Store
 */**/*.DS_Store
 .claude/settings.local.json

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ gem 'rake', '13.3.0'
 gem 'logger', '1.7.0'
 gem 'webrick', '1.9.1'
 gem 'listen', '3.9.0'
+gem 'sequel', '5.99.0'
+
+group :development do
+	gem 'sqlite3', '2.9.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,24 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    bigdecimal (4.0.1)
     ffi (1.17.2)
     ffi (1.17.2-arm64-darwin)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
+    mini_portile2 (2.8.9)
     minitest (5.25.4)
     rake (13.3.0)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    sequel (5.99.0)
+      bigdecimal
+    sqlite3 (2.9.0)
+      mini_portile2 (~> 2.8.0)
+    sqlite3 (2.9.0-arm64-darwin)
     webrick (1.9.1)
 
 PLATFORMS
@@ -23,6 +30,8 @@ DEPENDENCIES
   logger (= 1.7.0)
   minitest (= 5.25.4)
   rake (= 13.3.0)
+  sequel (= 5.99.0)
+  sqlite3 (= 2.9.0)
   webrick (= 1.9.1)
 
 RUBY VERSION

--- a/lib/runtime/error_formatter.rb
+++ b/lib/runtime/error_formatter.rb
@@ -10,7 +10,7 @@ module Ore
 		UNDERLINE = "\e[4m"
 		ITALIC    = "\e[3m"
 
-		def self.make str, foreground = "30", background = "41"
+		def self.make str, foreground = "31", background = "31"
 			enabled? ? "\x1b[#{foreground};#{background}m#{str}#{RESET}" : str
 		end
 
@@ -120,12 +120,14 @@ module Ore
 					end_char   = (line_num == l1) ? c1 : visual_content.length
 
 					# Convert character indices to visual (space-expanded) indices
-					visual_start_char = line_content[0...start_char].gsub("\t", "    ").length
-					visual_end_char   = line_content[0...end_char].gsub("\t", "    ").length
+					visual_start            = line_content[0...start_char].gsub("\t", "    ")
+					visual_end              = line_content[0...end_char].gsub("\t", "    ")
+					visual_start_char_count = visual_start.length
+					visual_end_char_count   = visual_end.length
 
-					before     = visual_content[0...visual_start_char]
-					error_span = visual_content[visual_start_char...visual_end_char]
-					after      = visual_content[visual_end_char..-1] || ""
+					before     = visual_content[0...visual_start_char_count]
+					error_span = visual_content[visual_start_char_count...visual_end_char_count]
+					after      = visual_content[visual_end_char_count..-1] || ""
 
 					# Apply color/style to the error span
 					styled_span = Colors.bold(Colors.red(error_span))
@@ -136,6 +138,12 @@ module Ore
 					end
 
 					snippet_lines << prefix + before + styled_span + after
+					spaces      = " " * visual_start_char_count
+					error_label = error_name.gsub '_', ' '
+
+					prefix     = Colors.cyan("#{' '.rjust(5)} | ")
+					error_line = spaces + Colors.bold(Colors.red("╰── " + error_label))
+					snippet_lines << prefix + error_line
 				else
 					# Regular surrounding line
 					snippet_lines << prefix + visual_content

--- a/lib/runtime/errors.rb
+++ b/lib/runtime/errors.rb
@@ -113,4 +113,7 @@ module Ore
 
 	class Lex_Char_Not_Implemented < Error
 	end
+
+	class Url_Not_Set_For_Database_Instance < Error
+	end
 end

--- a/ore/database.ore
+++ b/ore/database.ore
@@ -1,0 +1,15 @@
+Database {
+	adapter;
+	connection;
+	url;
+
+	`Creates a Sequel::SQLite::Database instance using ./adapter and ./url as configuration options. Populates ./connection with the instance, and returns it.
+	create_connection! {; #intrinsic }
+}
+
+Sqlite | Database {
+	new { url = './test/fixtures/sqlite_test.db';
+		adapter = 'sqlite'
+		./url = url
+	}
+}

--- a/ore/record.ore
+++ b/ore/record.ore
@@ -1,0 +1,3 @@
+Record {
+	table_name;
+}

--- a/test/database_test.rb
+++ b/test/database_test.rb
@@ -1,0 +1,51 @@
+require 'minitest/autorun'
+require_relative '../lib/ore'
+require_relative 'base_test'
+require 'net/http'
+require 'uri'
+
+class Database_Test < Base_Test
+	DATABASE = "#load 'ore/database.ore'"
+
+	def test_database_instance
+		out = Ore.interp <<~ORE
+		    #{DATABASE}
+			db = Database()
+		    sq = Sqlite()
+			(db, sq)
+		ORE
+		assert_instance_of Ore::Database, out.values.first
+		assert_instance_of Ore::Database, out.values.last
+
+		assert_nil out.values.first.get 'adapter'
+		assert_nil out.values.first.get 'url'
+		assert_nil out.values.first.get 'connection'
+		assert_nil out.values.last.get 'connection'
+
+		# These are set in Sqlite.new{;}
+		refute_nil out.values.last.get 'adapter'
+		refute_nil out.values.last.get 'url'
+	end
+
+	def test_database_connection_instance
+		out = Ore.interp <<~ORE
+		    #{DATABASE}
+		    db = Sqlite()
+		    db.create_connection!()
+			db.connection
+			db
+		ORE
+		refute_nil out.get 'connection'
+	end
+
+	def test_database_connection_is_cached
+		out = Ore.interp <<~ORE
+		    #{DATABASE}
+		    db = Sqlite()
+		    c1 = db.create_connection!()
+		    c2 = db.create_connection!()
+		    (c1, c2)
+		ORE
+		assert_equal out.values[0].object_id, out.values[1].object_id
+	end
+end

--- a/test/interpreter_test.rb
+++ b/test/interpreter_test.rb
@@ -1118,7 +1118,8 @@ class Interpreter_Test < Base_Test
 		out = Ore.interp "#load 'ore/preload.ore'; (Bool, Bool())"
 
 		assert_instance_of Ore::Type, out.values[0]
-		assert_instance_of Ore::Instance, out.values[1]
+		assert_kind_of Ore::Instance, out.values[1]
+		assert_instance_of Ore::Bool, out.values[1]
 	end
 
 	def test_standalone_load_into_current_scope

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -18,7 +18,7 @@ class Server_Test < Base_Test
 		ORE
 
 		result = Ore.interp code
-		assert_instance_of Ore::Instance, result
+		assert_instance_of Ore::Server, result
 		assert_equal 3000, result[:port]
 	end
 
@@ -41,7 +41,7 @@ class Server_Test < Base_Test
 		ORE
 
 		result = Ore.interp code
-		assert_instance_of Ore::Instance, result
+		assert_instance_of Ore::Server, result
 		assert_equal 3001, result[:port]
 	end
 
@@ -70,7 +70,7 @@ class Server_Test < Base_Test
 		interpreter = Ore::Interpreter.new Ore.parse(code)
 		result      = interpreter.output
 
-		assert_instance_of Ore::Instance, result
+		assert_instance_of Ore::Server, result
 
 		# Check that routes were registered
 		assert_equal 2, interpreter.runtime.routes.count


### PR DESCRIPTION
Refactor type instantiation

Improve the type system to dynamically instantiate Ore classes by convention:
- Replace hardcoded String case with dynamic const_get lookup for "Ore::{TypeName}"
- Only instantiate classes that are subclasses of Ore::Instance (excluding core runtime types)
- Add Database and Record instance types to support ORM functionality
- Change Html_Element, Bool, and Server to inherit from Instance instead of Scope/Type
- Update Bool initializer to allow parameterless instantiation (defaults to true)
- Remove unused Array#[]= method
- Update tests to verify correct instance types (Bool, Server) This refactoring enables automatic instantiation of any Ore type that follows the naming convention, eliminating the need to add new cases for each type with intrinsics.

Add Ore::Database

- Able to connect to sqlite database
- Wrote a few tests to test connection only
- Made Database.connect{;} an intrinsic function
- Generalized Interpreter#interp_type_call

Add Ore::Database

- Able to connect to sqlite database
- Wrote a few tests to test connection only
- Made Database.connect{;} an intrinsic function
- Generalized Interpreter#interp_type_call

Update error_formatter.rb

Delete sqlite_test.db

Delete sqlite_test.ore

Update .gitignore to include Sqlite databases

Add useful note

Simplify database and record

- Removed unimplemented declarations from Database and Record
- Moved Record into its own ore/record.ore file

Add foundation for Databases

- Simplified Ore::Database and Ore::Record
- Add error for missing url declaration that may be raised when trying to establish a connection to the database
- Add simple tests checking Ore::Database instances and connections