### PR TITLE
Add operator overloading and example usage

### DIFF
--- a/src/compiler/expressions.rb
+++ b/src/compiler/expressions.rb
@@ -130,6 +130,10 @@ module Ore
 		attr_accessor :custom, :precedence
 	end
 
+	class Operator_Overload_Expr < Expression
+		attr_accessor :func_expr, :fixity, :precedence
+	end
+
 	class Identifier_Expr < Expression
 		attr_accessor :kind, :unpack, :scope_operator, :directive, :privacy, :binding
 	end

--- a/src/compiler/parser.rb
+++ b/src/compiler/parser.rb
@@ -1,10 +1,15 @@
 module Ore
 	class Parser
-		attr_accessor :i, :input
+		attr_accessor :i, :input, :precedences
 
 		def initialize input = []
-			@input = input
-			@i     = 0 # index of current lexeme
+			@precedences = PRECEDENCES.dup
+			# Track these so that they can be considered during parse-time
+			@custom_infix   = ::Set.new
+			@custom_prefix  = ::Set.new
+			@custom_postfix = ::Set.new
+			@input          = input
+			@i              = 0 # index of current lexeme
 		end
 
 		def input= value
@@ -24,16 +29,43 @@ module Ore
 		end
 
 		def output
+			scan_and_register_operator_overloads_before_parsing # This has to be done before parsing because overloaded operators have to set their precedence level, which if done at runtime would the behavior of #precedence_for that now depends on an updated prcedence table with new precedences added.
+
 			expressions = []
 			while lexemes?
 				expressions << parse_expression
 			end
+
 			expressions.compact
 		end
 
-		# Array of precedences and symbols for that precedence. if the lexeme provided matches one of the operator symbols then its precedence is returned. Nice reference: https://rosettacode.org/wiki/Operator_precedence
+		def scan_and_register_operator_overloads_before_parsing
+			# The pattern:    @   operator   {user_operator}   @   {fixity}   {precedence_integer}
+			#                 t0  t1          user_operator    t3   fixity     prec
+			input.each_cons(6) do |t0, t1, user_operator, t3, fixity, prec|
+				next unless t0.value == '@' && t1.value == 'operator' && t3.value == '@'
+
+				fixities = %w(infix prefix postfix circumfix)
+				raise Operator_Overload_Fixity_Must_Be_One_Of.new(fixities) unless fixities.include? fixity.value
+				raise Operator_Overload_Precedence_Must_Be_Integer.new(prec) unless prec.type == :number
+
+				# note: I know this allows users to overload precedence. Sounds fun.
+				@precedences[user_operator.value] = prec.value.to_i
+
+				case fixity.value
+				when 'infix' then @custom_infix << user_operator.value
+				when 'prefix' then @custom_prefix << user_operator.value
+				when 'postfix' then @custom_postfix << user_operator.value
+				end
+			end
+		end
+
+		# If the given operator doesn't exist then it returns Ore::DEFAULT_OPERATOR_PRECEDENCE which binds somewhere around the equality operators. See Ore::PRECEDENCES
+		# Neat reference for precedences: https://rosettacode.org/wiki/Operator_precedence
+		# @param operator [::String]
+		# @return precedence [Integer]
 		def precedence_for operator
-			PRECEDENCES[operator] || STARTING_PRECEDENCE
+			@precedences[operator] || DEFAULT_OPERATOR_PRECEDENCE
 		end
 
 		# input[i - 1]
@@ -237,7 +269,7 @@ module Ore
 			until curr? Ore::FUNCTION_DELIMITER
 				param        = Ore::Param_Expr.new
 
-				if curr? Ore::RUNTIME_SCOPE_OPERATOR and eat Ore::RUNTIME_SCOPE_OPERATOR
+				if curr? Ore::DIRECTIVE_OPERATOR and eat Ore::DIRECTIVE_OPERATOR
 					param.unpack = true
 				end
 
@@ -358,7 +390,7 @@ module Ore
 
 			expr = Ore::Identifier_Expr.new
 
-			if curr? RUNTIME_SCOPE_OPERATOR and eat RUNTIME_SCOPE_OPERATOR
+			if curr? DIRECTIVE_OPERATOR and eat DIRECTIVE_OPERATOR
 				expr.directive = true
 			elsif curr? SCOPE_OPERATORS
 				expr.scope_operator = parse_scope_operator
@@ -525,7 +557,7 @@ module Ore
 			elsif curr? %w(if while unless until)
 				parse_conditional_expr
 
-			elsif curr?(:identifier, ':', :Identifier) || curr?(ANY_IDENTIFIER) || curr?(Ore::RUNTIME_SCOPE_OPERATOR, :identifier) || curr?(SCOPE_OPERATORS, ANY_IDENTIFIER) || curr?(RUNTIME_SCOPE_OPERATOR, :identifier)
+			elsif curr?(:identifier, ':', :Identifier) || curr?(ANY_IDENTIFIER) || curr?(Ore::DIRECTIVE_OPERATOR, :identifier) || curr?(SCOPE_OPERATORS, ANY_IDENTIFIER) || curr?(DIRECTIVE_OPERATOR, :identifier)
 				parse_identifier_expr
 
 			elsif curr?(%w( [ \( { |)) && curr?(:delimiter)
@@ -594,11 +626,52 @@ module Ore
 
 			if expr.is_a?(Ore::Identifier_Expr) && expr.directive && expr.value != 'super'
 				# note: I'm intentionally skipping `super` here because a Directive_Expr assumes an expression will follow it. But in the case of @super, I want it to be a standalone expression. Maybe this warrants rewriting how directives work? Or maybe this can just stay as an implementation detail. For now it's fine.
-				directive            = Ore::Directive_Expr.new
-				directive.name       = expr
-				directive.expression = parse_expression
-
+				directive      = Ore::Directive_Expr.new
+				directive.name = expr
 				copy_location directive, expr
+
+				# Here I'm intercepting when an @operator directive is found, so that I can prebuild a special expression for operator overloads. Just FYI, this massive if body ends with a return statement,
+				if expr.value == 'operator'
+					unless curr? %i(operator identifier)
+						raise "@operator directive requires an operator identifier made of symbols. Hold shift and press some numbers... rules tbd!"
+					end
+					op_lexeme            = eat # Eat the :operator or :identifier token directly. Going through parse_expression would apply custom fixity rules that are pre-registered and would misparse the operator in its own declaration.
+					unless %i(operator identifier).include? op_lexeme.type
+						raise "An operator can only by an operator or identifier.. what a stupid message."
+					end
+					operator_expr        = Ore::Operator_Expr.new op_lexeme
+					directive.expression = operator_expr
+					copy_location operator_expr, op_lexeme
+
+					# If @operator <Op_Expr> is followed by @infix <Num_Expr> then we have a complete operator overload expression
+					next_expr = begin_expression
+					if next_expr.is_a?(Ore::Identifier_Expr) && next_expr.directive
+						if %w(prefix infix postfix circumfix).include? next_expr.value
+							subdirective      = Ore::Directive_Expr.new
+							subdirective.name = next_expr
+							copy_location subdirective, next_expr
+
+							subdirective.expression = parse_expression
+							unless subdirective.expression.is_a?(Ore::Number_Expr)
+								raise "an operator overload requires the following form: `@operator + @infix 90 {left, right; ...}`"
+							end
+
+							# If you can't wrap your mind around this. At this point we know `@operator + @infix 90` so all that's left to parse is the function
+							overload            = Ore::Operator_Overload_Expr.new operator_expr.lexeme
+							overload.fixity     = subdirective.name.lexeme
+							overload.precedence = subdirective.expression.value
+							overload.func_expr  = parse_func
+							overload.value      = operator_expr.lexeme.value
+
+							return complete_expression overload, precedence
+						end
+					else
+						return complete_expression next_expr, precedence
+					end
+				else
+					directive.expression = parse_expression
+				end
+
 				return complete_expression directive, precedence
 			end
 
@@ -616,9 +689,9 @@ module Ore
 				return complete_expression next_expr, precedence
 			end
 
-			prefix    = PREFIX.include?(expr.value)
-			infix     = INFIX.include?(curr_lexeme.value)
-			postfix   = POSTFIX.include?(curr_lexeme.value)
+			prefix    = !expr.is_a?(Ore::Operator_Overload_Expr) && (PREFIX.include?(expr.value) || (expr.is_a?(Ore::Operator_Expr) && @custom_prefix.include?(expr.value)))
+			infix     = INFIX.include?(curr_lexeme.value) || @custom_infix.include?(curr_lexeme.value)
+			postfix   = POSTFIX.include?(curr_lexeme.value) || @custom_postfix.include?(curr_lexeme.value)
 			circumfix = CIRCUMFIX.include?(curr_lexeme.value)
 
 			if prefix
@@ -657,7 +730,7 @@ module Ore
 					copy_location it, expr
 					return complete_expression it, precedence
 				else
-					while INFIX.include?(curr_lexeme.value) && curr?(:operator)
+					while (INFIX.include?(curr_lexeme.value) || @custom_infix.include?(curr_lexeme.value)) && curr?(:operator)
 						# It's very important that the curr?(:operator) check here remains because otherwise it breaks Ore::Call_Expr when the receiver is an Ore::Infix_Expr.
 						curr_operator      = curr_lexeme.value
 						curr_operator_prec = precedence_for curr_operator
@@ -686,10 +759,10 @@ module Ore
 					end
 				end
 
-			elsif postfix
+			elsif postfix && precedence_for(curr_lexeme.value) > precedence
 				expr = Ore::Postfix_Expr.new.tap do |it|
 					it.expression = expr
-					it.operator   = eat(:operator)
+					it.operator   = eat(%i(operator identifier))
 				end
 			end
 

--- a/src/runtime/errors.rb
+++ b/src/runtime/errors.rb
@@ -158,4 +158,10 @@ module Ore
 			"Type contract violation: expected #{@contract}, got #{@actual || 'unknown'}"
 		end
 	end
+
+	class Operator_Overload_Fixity_Must_Be_One_Of < Error
+	end
+
+	class Operator_Overload_Precedence_Must_Be_Integer < Error
+	end
 end

--- a/src/runtime/interpreter.rb
+++ b/src/runtime/interpreter.rb
@@ -702,7 +702,14 @@ module Ore
 				returned = interpret expr.expression
 				Ore::Return.new returned
 			else
-				raise Ore::Unhandled_Prefix.new(expr, self)
+				overload_func = stack.reverse_each.find { |s| s.has? expr.operator.value }&.get(expr.operator.value)
+				if overload_func.is_a? Ore::Func
+					call           = Ore::Call_Expr.new
+					call.arguments = [expr.expression]
+					interp_func_body overload_func, call
+				else
+					raise Ore::Unhandled_Prefix.new(expr, self)
+				end
 			end
 		end
 
@@ -976,7 +983,18 @@ module Ore
 					end
 				end
 			else
-				if expr.left.value == Ore::RUNTIME_SCOPE_OPERATOR
+				# We're checking for operator overloads first, then the default operator functionality is the fallback. Operator overloads are normal functions that take its operands as arguments, declared on the stack. We're looking them up as if they were regular named functions.
+				overload_func = stack.reverse_each.find do |s|
+					s.has? expr.operator.value
+				end&.get(expr.operator.value)
+
+				if overload_func.is_a? Ore::Func
+					call           = Ore::Call_Expr.new
+					call.arguments = [expr.left, expr.right]
+					return interp_func_body overload_func, call
+				end
+
+				if expr.left.value == Ore::DIRECTIVE_OPERATOR
 					case expr.operator.value
 					when '+='
 						right = interpret expr.right
@@ -1041,9 +1059,22 @@ module Ore
 			end
 		end
 
+		# @param expr [Ore::Postfix_Expr]
 		def interp_postfix expr
 			# note: See constants.rb POSTFIX for exhaustive list of language-defined postfixes. Currently there are no built-in postfix operators.
-			raise Ore::Unhandled_Postfix.new(expr, self)
+			# 1) look up the opreator (expr.operator.value) as it should be a normal func in the scope.
+			# 2) call it with expr.expression as its argument. It should only take one argument.
+			postfix_overloaded_func = stack.reverse_each.find do |s|
+				s.has? expr.operator.value
+			end&.get(expr.operator.value)
+
+			if !postfix_overloaded_func
+				raise "Could not find #{expr.operator.value} declared anywhere man!"
+			end
+
+			call           = Ore::Call_Expr.new
+			call.arguments = [expr.expression]
+			interp_func_body postfix_overloaded_func, call
 		end
 
 		def interp_circumfix expr
@@ -1228,6 +1259,7 @@ module Ore
 
 		def interp_func expr
 			func                 = Ore::Func.new expr.lexeme
+			func.name            = expr.lexeme
 			func.enclosing_scope = stack.last
 			func.expressions     = expr.expressions
 
@@ -1807,6 +1839,14 @@ module Ore
 			end
 		end
 
+		# @param expr [Ore::Operator_Overload_Expr]
+		def interp_operator_overload expr
+			# expr attrs:  func_expr(Func_Expr)  fixity(Lexeme)  precedence(Int)  value(String)
+			# This is setting up operators to be treated as regular functions, whose identifier is its operator symbols without spaces.
+
+			stack.last.declare expr.value, interpret(expr.func_expr)
+		end
+
 		# note: This is the entry point for all expressions. This is called in a loop until all expressions are evaluated, or the program crashes.
 		def interpret expr
 			case expr
@@ -1873,6 +1913,9 @@ module Ore
 
 			when Ore::Comment_Expr
 				expr.value
+
+			when Ore::Operator_Overload_Expr
+				interp_operator_overload expr
 
 			when Ore::Operator_Expr
 				case expr.value

--- a/src/shared/constants.rb
+++ b/src/shared/constants.rb
@@ -1,19 +1,20 @@
 module Ore
-	RUNTIME_SCOPE_OPERATOR     = '@'
-	NIL_INIT_POSTFIX           = ','
-	FUNCTION_DELIMITER         = ';'
-	IMPORT_FILE_DIRECTIVE      = 'use'
-	FOR_VERBS                  = %w(each map select reject count)
-	HTML_ATTRS                 = %w(id class href)
-	HTTP_VERBS                 = %w(get put patch post delete head options connect trace)
-	VOID_HTML_TAGS             = %w(area base br col command embed hr img input keygen link meta param source track wbr)
-	HTTP_VERB_SEPARATOR        = '://'
-	BROWSER_VIEW_SIZE          = 'browser_view_size'
-	INTERPOLATE_CHAR           = '`' # easily distinguishable betwen ```
-	COMMENT_CHAR               = '#'
-	FENCE_CHARS                = '```'
-	PREFIX                     = %w(! - + ~ not return)
-	INFIX                      = %w(
+	DIRECTIVE_OPERATOR          = '@'
+	UNPACK_OPERATOR             = '@' # todo: Pick a different symbol
+	NIL_INIT_POSTFIX            = ','
+	FUNCTION_DELIMITER          = ';'
+	IMPORT_FILE_DIRECTIVE       = 'use'
+	FOR_VERBS                   = %w(each map select reject count)
+	HTML_ATTRS                  = %w(id class href)
+	HTTP_VERBS                  = %w(get put patch post delete head options connect trace)
+	VOID_HTML_TAGS              = %w(area base br col command embed hr img input keygen link meta param source track wbr)
+	HTTP_VERB_SEPARATOR         = '://'
+	BROWSER_VIEW_SIZE           = 'browser_view_size'
+	INTERPOLATE_CHAR            = '`' # easily distinguishable betwen ```
+	COMMENT_CHAR                = '#'
+	FENCE_CHARS                 = '```'
+	PREFIX                      = %w(! - + ~ not return)
+	INFIX                       = %w(
 		+ - ^ * ** / % ~ == === ? . .?
 		= := : ||= &&= **= <<= >>= += -= *= |= /= %= &= ^=
 		&& || & | << >>
@@ -21,27 +22,28 @@ module Ore
 		!= <= >= < > <=> < >
 		and or
 	)
-	POSTFIX                    = %w() # note: ; can never be a postfix, it's reserved
-	CIRCUMFIX                  = %w( \( [ { | )
-	CIRCUMFIX_GROUPINGS        = { '(' => '()', '{' => '{}', '[' => '[]', '|' => '||' }.freeze
-	LOGICAL_OPERATORS          = %w(&& & || | and or)
-	COMPOUND_OPERATORS         = %w(||= &&= **= <<= >>= += -= *= |= /= %= &= ^=)
-	COMPARISON_OPERATORS       = %w(<=> == === != !== <= >= < > =~ !~)
-	INFIX_ARITHMETIC_OPERATORS = %w(+ - * ** / % << >> ^ & |)
-	RANGE_OPERATORS            = %w(.. .< >. ><)
-	SCOPE_OPERATORS            = %w(. ./ ../)
-	DOT_ACCESS_OPERATORS       = %w(. .?)
-	TYPE_COMPOSITION_OPERATORS = %w(| & ~ ^) # Union, Intersection, Removal, Symmetric Difference
-	ANY_IDENTIFIER             = %i(identifier Identifier IDENTIFIER)
-	GSCOPE                     = :global
-	STARTING_PRECEDENCE        = 0
-	DELIMITERS                 = %W(, ; { } ( ) [ ] \n \r).freeze
-	NEWLINES                   = %W(\r\n \n).freeze
-	WHITESPACES                = %W(\t \s).freeze
-	NUMERIC_REGEX              = /\A\d+\z/
-	ALPHA_REGEX                = /\A\p{Alpha}+\z/
-	ALPHANUMERIC_REGEX         = /\A\p{Alnum}+\z/
-	SYMBOLIC_REGEX             = /\A[^\p{Alnum}\s]+\z/
+	POSTFIX                     = %w() # note: ; can never be a postfix, it's reserved
+	CIRCUMFIX                   = %w( \( [ { | )
+	CIRCUMFIX_GROUPINGS         = { '(' => '()', '{' => '{}', '[' => '[]', '|' => '||' }.freeze
+	LOGICAL_OPERATORS           = %w(&& & || | and or)
+	COMPOUND_OPERATORS          = %w(||= &&= **= <<= >>= += -= *= |= /= %= &= ^=)
+	COMPARISON_OPERATORS        = %w(<=> == === != !== <= >= < > =~ !~)
+	INFIX_ARITHMETIC_OPERATORS  = %w(+ - * ** / % << >> ^ & |)
+	RANGE_OPERATORS             = %w(.. .< >. ><)
+	SCOPE_OPERATORS             = %w(. ./ ../)
+	DOT_ACCESS_OPERATORS        = %w(. .?)
+	TYPE_COMPOSITION_OPERATORS  = %w(| & ~ ^) # Union, Intersection, Removal, Symmetric Difference
+	ANY_IDENTIFIER              = %i(identifier Identifier IDENTIFIER)
+	GSCOPE                      = :global
+	STARTING_PRECEDENCE         = 0
+	DEFAULT_OPERATOR_PRECEDENCE = 500 # given to all custom operators at runtime unless
+	DELIMITERS                  = %W(, ; { } ( ) [ ] \n \r).freeze
+	NEWLINES                    = %W(\r\n \n).freeze
+	WHITESPACES                 = %W(\t \s).freeze
+	NUMERIC_REGEX               = /\A\d+\z/
+	ALPHA_REGEX                 = /\A\p{Alpha}+\z/
+	ALPHANUMERIC_REGEX          = /\A\p{Alnum}+\z/
+	SYMBOLIC_REGEX              = /\A[^\p{Alnum}\s]+\z/
 
 	# It's been a while, but I believe this RESERVED list must be maintained. The other declarations above are helpers for comparisons while this contains every reserved symbols and identifiers.
 	RESERVED = %w(

--- a/test/interpreter_test.rb
+++ b/test/interpreter_test.rb
@@ -2203,7 +2203,7 @@ class Interpreter_Test < Base_Test
 	# if abc exists, use that value
 	# if not abc exists, declare abc=nil
 	def test_walrus_basic_assignment
-		assert_equal 4,       Ore.interp('x := 4, x')
+		assert_equal 4, Ore.interp('x := 4, x')
 		assert_equal 'hello', Ore.interp('x := "hello", x')
 	end
 
@@ -2245,5 +2245,107 @@ class Interpreter_Test < Base_Test
 		    abc=2, (abc,1),
 		CODE
 		assert_equal [2, 1], out.values
+	end
+
+	def test_neat_usage_of_operator_overloads
+		prelude = <<~CODE
+		    Time {
+		    	hour, minute, second,
+		    	period, # am/pm
+		    }
+
+		    @operator : @infix 700 { hour, minute;
+		    	time = Time()
+		    	time.hour = hour
+		    	time.minute = minute
+		    	time
+		    }
+
+		    @operator pm @postfix 600 { left: Time;
+		        left.period = 'pm'
+		        left
+		    }
+		CODE
+
+		out = Ore.interp <<~CODE
+		    #{prelude}
+			# You can now make `11:22pm` evaluate to something!
+			11:22pm
+		CODE
+		assert_instance_of Ore::Instance, out
+		assert_equal 11, out.get('hour')
+		assert_equal 22, out.get('minute')
+		assert_equal 'pm', out.get('period')
+	end
+
+	def test_prefix_operator_overload
+		out = Ore.interp <<~CODE
+		    Currency {
+		    	amount,
+		    	name,
+		    	code,
+		    }
+
+		    @operator $ @prefix 900 { amount;
+		    	c = Currency()
+		    	c.amount = amount
+		    	c.name = 'US Dollar'
+		    	c.code = 'USD'
+		    	c
+		    }
+
+		    $42
+		CODE
+		assert_instance_of Ore::Instance, out
+		assert_equal 42, out.get('amount')
+		assert_equal 'US Dollar', out.get('name')
+		assert_equal 'USD', out.get('code')
+	end
+
+	def test_operator_overload_scoped_to_function
+		out = Ore.interp <<~CODE
+		    scoped_result = compute {;
+		    	@operator + @infix 700 { left, right;
+		    		left * right
+		    	}
+		    	3 + 4
+		    }
+
+		    normal_result = 3 + 4
+
+		    [scoped_result(), normal_result]
+		CODE
+
+		assert_equal [12, 7], out.values
+	end
+
+	def test_whacky_prefix_operator_overload
+		out = Ore.interp <<~CODE
+		    @operator !! @prefix 900 { n;
+		    	n * n
+		    }
+
+		    !!5
+		CODE
+		assert_equal 25, out
+	end
+
+	def test_pipeing_with_operator_overloads
+		out = Ore.interp <<~CODE
+		    @operator -> @infix 300 { left, right;
+		    	right(left)
+		    }
+
+		    double { n;
+				n * 2
+			}
+
+		    add_fifteen { n;
+				n + 15
+			}
+
+		    4 -> double -> add_fifteen
+		CODE
+		assert_equal 23, out
 	end
 end

--- a/test/lexer_test.rb
+++ b/test/lexer_test.rb
@@ -375,7 +375,7 @@ class Lexer_Test < Base_Test
 	def test_unpack_prefix
 		out = Ore.lex '@instance_to_unpack'
 		assert_equal :operator, out.first.type
-		assert_equal Ore::RUNTIME_SCOPE_OPERATOR, out.first.value
+		assert_equal Ore::UNPACK_OPERATOR, out.first.value
 		assert_equal :identifier, out.last.type
 		assert_equal 'instance_to_unpack', out.last.value
 	end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -880,4 +880,46 @@ class Parser_Test < Base_Test
 		# The 'html' marker should be stripped from body
 		refute html_fence.body.value.start_with?('html')
 	end
+
+	def test_operator_overload_parses
+		assert_raises Ore::Operator_Overload_Fixity_Must_Be_One_Of do
+			Ore.parse <<~CODE
+			    @operator := @heehee 500 { left, right; }
+			CODE
+		end
+
+		assert_raises Ore::Operator_Overload_Precedence_Must_Be_Integer do
+			Ore.parse <<~CODE
+			    @operator $ @prefix hmm { left, right; }
+			CODE
+		end
+
+		assert_raises Ore::Operator_Overload_Precedence_Must_Be_Integer do
+			Ore.parse <<~CODE
+			    @operator + @infix notanumber { left, right; }
+			CODE
+		end
+
+		out      = Ore.parse '@operator := @infix 500 { left, right; }'
+		overload = out.first
+		assert_instance_of Ore::Operator_Overload_Expr, overload
+		assert_equal ':=', overload.value
+		assert_equal 'infix', overload.fixity.value
+		assert_equal 500, overload.precedence
+		assert_instance_of Ore::Func_Expr, overload.func_expr
+
+		{ 'infix' => '~~', 'prefix' => '!!', 'postfix' => '??' }.each do |fixity, op|
+			refute_raises do
+				Ore.parse "@operator #{op} @#{fixity} 300 { x; x }"
+			end
+		end
+
+		# Operator is registered so it can appear in a subsequent expression as Infix_Expr
+		out   = Ore.parse "@operator ~> @infix 700 { left, right; left }\na ~> b"
+		infix = out.last
+		assert_instance_of Ore::Infix_Expr, infix
+		assert_equal '~>', infix.operator.value
+		assert_equal 'a', infix.left.value
+		assert_equal 'b', infix.right.value
+	end
 end


### PR DESCRIPTION
- expressions.rb: Added Operator_Overload_Expr node with fixity, precedence, and func_expr attributes
- constants.rb: Renamed RUNTIME_SCOPE_OPERATOR to DIRECTIVE_OPERATOR, added DEFAULT_OPERATOR_PRECEDENCE = 500 as the fallback for undeclared custom operators
- parser.rb: Added pre-scan step that walks the token stream before parsing to register custom operator precedences and fixities; extended infix/postfix/prefix checks to consult custom fixity sets alongside the static constants; fixed postfix to respect precedence so binding order works correctly (e.g. 11:22pm); guarded Operator_Overload_Expr from accidentally triggering its own operator's prefix handling
- errors.rb: Added Operator_Overload_Fixity_Must_Be_One_Of and Operator_Overload_Precedence_Must_Be_Integer error classes
- interpreter.rb: Added interp_operator_overload which declares the operator as a named function in the current scope; extended interp_infix, interp_prefix, and interp_postfix to check the stack for an overload function first and call it via interp_func_body, falling through to built-in behaviour if none found
- parser_test.rb: Tests for valid and invalid operator overload declarations, correct Operator_Overload_Expr shape, and that a declared infix operator parses subsequent expressions correctly
- interpreter_test.rb: Tests for 11:22pm producing a Time instance, $42 producing a Currency instance, and a scoped + overload that multiplies without affecting the global +
- lexer_test.rb: Updated reference from RUNTIME_SCOPE_OPERATOR to UNPACK_OPERATOR after the rename