### PR TITLE
Rename record to table

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,7 +71,7 @@ Source code is tokenized, parsed into an AST, and statically type checked:
 
 The AST is executed to produce output:
 
-- `interpreter.rb` - The running program; owns `@lexer`, `@parser`, and all execution state (`stack`, `routes`, `servers`, `loaded_files`, etc.); `run(source)` is the entry point; handles file loading via `load_file_into_scope`
+- `interpreter.rb` - The running program; owns `@lexer`, `@parser`, and all execution state (`stack`, `routes`, `servers`, `cached_expressions_by_filepath`, etc.); `run(source)` is the entry point; handles file loading via `load_file_into_scope`
 - `scopes.rb` - All scope types and built-in types:
 	- `Global < Scope` - The global scope; pushed as the bottom of the stack on first `run`; standard library declarations live here
 	- `Type`, `Instance`, `Func`, `Route`, `Return` - Scope hierarchy
@@ -760,6 +760,6 @@ Styled_Div | Dom {
 
 The `@use` directive allows importing Ore files:
 
-.- Interpreter tracks loaded files in `@loaded_files` to prevent duplicate parsing
+- Interpreter caches parsed expressions in `@cached_expressions_by_filepath` to prevent duplicate parsing
 - Files are loaded into a specified scope via `Interpreter#load_file_into_scope`
-- Expressions are cached in `@loaded_files` keyed by resolved filepath
+- Expressions are cached keyed by resolved filepath

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -573,7 +573,7 @@ Tests use Minitest and inherit from `Base_Test` (in test/base_test.rb):
 - `test/lexer_test.rb` - Lexer tests
 - `test/parser_test.rb` - Parser tests
 - `test/interpreter_test.rb` - Interpreter tests
-- `test/proxies_test.rb` - Super Proxy method tests
+- `test/proxies_test.rb` - Ruby Proxy method tests
 - `test/regression_test.rb` - Regression tests
 - `test/server_test.rb` - Server and routing tests
 - `test/e2e_server_test.rb` - End-to-end server tests

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -314,7 +314,7 @@ thingy { @island;
 
 ## Built-in Types and Intrinsic Methods
 
-Ore's built-in types (String, Array, Dictionary, Number) have ruby methods that delegate to Ruby's native implementations. These methods are declared using a `proxy_` prefix (see src/shared/super_proxies.rb)
+Ore's built-in types (String, Array, Dictionary, Number) have ruby methods that delegate to Ruby's native implementations. These methods are declared using a `proxy_` prefix (see src/shared/ruby_proxies.rb)
 
 ### Intrinsic Method Implementation Pattern
 
@@ -322,8 +322,8 @@ Ore's built-in types (String, Array, Dictionary, Number) have ruby methods that 
 
 ```ore
 String {
-    upcase {; @super }
-    downcase {; @super }
+    upcase {; @ruby }
+    downcase {; @ruby }
 }
 ```
 
@@ -332,7 +332,7 @@ String {
 ```ruby
 
 class String < Instance
-	extend Super_Proxies
+	extend Ruby_Proxies
 
 	proxy_delegate 'value' # Delegate to @value
 	proxy :upcase # Calls @value.upcase

--- a/examples/game.ore
+++ b/examples/game.ore
@@ -1,0 +1,51 @@
+@use 'ore/database.ore'
+
+Position {
+	C = 0
+	LW = 1
+	RW = 2
+	LD = 3
+	RD = 4
+	G = 5
+	ANY = 6
+
+}
+
+Player | Table {
+	id,
+
+	# Identity
+	prefix,
+	first_name,
+	middle_name,
+	last_name,
+	suffix,
+	age,
+	language,
+	planet,
+	species,
+	university,
+
+	# Physical
+	height_in_cm = 150
+	weight_in_kg = 75
+	hand = 0
+
+	# Position
+	natural_position = Position.ANY
+	current_position,
+
+	# Game attributes
+	max_mods,
+	qualities = {}
+	chemistries = {}
+	connections = []
+	average_chemistry,
+	strategy_id,
+
+	# Associations
+	team_id,
+	user_id,
+}
+
+'height: `Position.ANY == Position.C`'

--- a/examples/operator_overloads.ore
+++ b/examples/operator_overloads.ore
@@ -92,3 +92,16 @@ outer = 3 + 4
 @assert outer == 7
 
 (outer, result)
+
+
+```
+Alternate syntax to consider
+
+@prefix $ 900 { amount;
+	c = Currency()
+	c.amount = amount
+	c.name = 'US Dollar'
+	c.code = 'USD'
+	c
+}
+```

--- a/examples/todo_app.ore
+++ b/examples/todo_app.ore
@@ -1,6 +1,6 @@
 @use 'ore/html.ore'
 @use 'ore/database.ore'
-@use 'ore/record.ore'
+@use 'ore/Table.ore'
 @use 'ore/server.ore'
 
 ```Page components```
@@ -88,7 +88,7 @@ db = Sqlite('./temp/task_app.db') # Sqlite composes with Database
 # db = @connect Sqlite(...) is also valid
 @connect db  # => calls Database#create_connection!
 
-Task | Record {
+Task | Table {
 	./database = ../db # Must set the database in order for Task query methods to work
 	table_name = 'tasks'
 }
@@ -101,7 +101,7 @@ else
 end
 
 Task.create({text: "Make Databases work"})
-Task.create({text: "Allow reading and writing Records"})
+Task.create({text: "Allow reading and writing Tables"})
 Task.create({text: "Show Tasks in this app"})
 Task.create({text: "Implement user authentication"})
 Task.create({text: "Add dark mode toggle"})

--- a/ore/array.ore
+++ b/ore/array.ore
@@ -5,24 +5,24 @@ Array {
 		.values = values
 	}
 
-	push { item; @super }
-	random {; @super }
-	pop {; @super }
-	shift {; @super }
-	unshift { item; @super }
-	length {; @super }
-	first { count; @super }
-	last { count; @super }
-	slice { from, to; @super }
-	reverse {; @super }
-	join { separator; @super }
-	concat { other; @super }
-	flatten {; @super }
-	sort {; @super }
-	uniq {; @super }
-	include? { item; @super }
-	empty? {; @super }
-	get { index; @super }
+	push { item; @ruby }
+	random {; @ruby }
+	pop {; @ruby }
+	shift {; @ruby }
+	unshift { item; @ruby }
+	length {; @ruby }
+	first { count; @ruby }
+	last { count; @ruby }
+	slice { from, to; @ruby }
+	reverse {; @ruby }
+	join { separator; @ruby }
+	concat { other; @ruby }
+	flatten {; @ruby }
+	sort {; @ruby }
+	uniq {; @ruby }
+	include? { item; @ruby }
+	empty? {; @ruby }
+	get { index; @ruby }
 
 	find { func;
 		for values

--- a/ore/database.ore
+++ b/ore/database.ore
@@ -3,10 +3,10 @@ Database {
 	connection, # todo: Make a type for this, currently it stores an Sequel::SQLite::Database instance
 	url,
 
-	create_table { name, columns_dict; @super }
-	delete_table { name; @super }
-	tables {; @super }
-	table_exists? { name; @super }
+	create_table { name, columns_dict; @ruby }
+	delete_table { name; @ruby }
+	tables {; @ruby }
+	table_exists? { name; @ruby }
 }
 
 Sqlite | Database {

--- a/ore/dictionary.ore
+++ b/ore/dictionary.ore
@@ -1,11 +1,11 @@
 Dictionary {
-	keys {; @super }
-	values {; @super }
-	has_key? { key; @super }
-	delete { key; @super }
-	merge { other; @super }
-	count {; @super }
-	empty? {; @super }
-	clear {; @super }
-	fetch { key, default; @super }
+	keys {; @ruby }
+	values {; @ruby }
+	has_key? { key; @ruby }
+	delete { key; @ruby }
+	merge { other; @ruby }
+	count {; @ruby }
+	empty? {; @ruby }
+	clear {; @ruby }
+	fetch { key, default; @ruby }
 }

--- a/ore/file_system.ore
+++ b/ore/file_system.ore
@@ -1,5 +1,5 @@
 File_System {
 	./read { filepath; read_file_to_string(filepath) }
-	./read_file_to_string { filepath; @super }
-	./write_string_to_file { filepath, string; @super }
+	./read_file_to_string { filepath; @ruby }
+	./write_string_to_file { filepath, string; @ruby }
 }

--- a/ore/number.ore
+++ b/ore/number.ore
@@ -8,16 +8,16 @@ Number {
 		.denominator = 1
 	}
 
-	clamp { min, max; @super }
-	./rand { max; @super }
-	to_s {; @super }
-	abs {; @super }
-	floor {; @super }
-	ceil {; @super }
-	round {; @super }
-	sqrt {; @super }
-	even? {; @super }
-	odd? {; @super }
-	to_i {; @super }
-	to_f {; @super }
+	clamp { min, max; @ruby }
+	./rand { max; @ruby }
+	to_s {; @ruby }
+	abs {; @ruby }
+	floor {; @ruby }
+	ceil {; @ruby }
+	round {; @ruby }
+	sqrt {; @ruby }
+	even? {; @ruby }
+	odd? {; @ruby }
+	to_i {; @ruby }
+	to_f {; @ruby }
 }

--- a/ore/number.ore
+++ b/ore/number.ore
@@ -8,8 +8,9 @@ Number {
 		.denominator = 1
 	}
 
+	./rand { max = 1; @ruby }
+
 	clamp { min, max; @ruby }
-	./rand { max; @ruby }
 	to_s {; @ruby }
 	abs {; @ruby }
 	floor {; @ruby }

--- a/ore/preload.ore
+++ b/ore/preload.ore
@@ -1,4 +1,4 @@
-# Builtin types I'm experimenting with, very much incomplete. Each of these should have an equivalent Ore::Type in src/runtime/scopes.rb
+# Builtin types I'm experimenting with, very much incomplete. Each of these should have an equivalent Ore::Type in ./src/runtime/scopes.rb
 
 @use 'ore/file_system.ore'
 @use 'ore/number.ore'

--- a/ore/record.ore
+++ b/ore/record.ore
@@ -1,13 +1,13 @@
 Record {
 	table_name,
-	infer_table_name_from_class! {; @super }
+	infer_table_name_from_class! {; @ruby }
 
 	./database,
-	./all {; @super }
-	./find { id; @super }
-	./find_by { dict; @super }
-	./where { dict; @super }
-	./create { dict; @super }
-	./update { id, dict; @super }
-	./delete { id; @super }
+	./all {; @ruby }
+	./find { id; @ruby }
+	./find_by { dict; @ruby }
+	./where { dict; @ruby }
+	./create { dict; @ruby }
+	./update { id, dict; @ruby }
+	./delete { id; @ruby }
 }

--- a/ore/server.ore
+++ b/ore/server.ore
@@ -12,8 +12,9 @@ Response {
 	headers,
 	body,
 
-	redirect { location; @super }
+	redirect { location; @ruby }
 }
+
 
 Server {
 	port,
@@ -22,14 +23,13 @@ Server {
 		.port = port
 	}
 
-	# note: The following routes prevent 500 errors since we're handling all routes here, nothing is filtered.
-	get://favicon.ico {;
+	ok200 {;
 		response.status = 200
 		''
 	}
 
-	get://apple-touch-icon-precomposed.png {;
-		response.status = 200
-		''
-	}
+	# note: The following routes prevent 500 errors since we're handling all routes here, nothing is filtered.
+	get://favicon.ico ok200
+
+	get://apple-touch-icon-precomposed.png ok200
 }

--- a/ore/string.ore
+++ b/ore/string.ore
@@ -10,24 +10,24 @@ String {
 		.value = value
 	}
 
-	downcase {; @super }
-	upcase {; @super }
-	split { delimiter = nil; @super } # todo: Without the default nil value, .split() fails
-    slice { substr; @super }
-    trim {; @super }
-	trim_left {; @super }
-	trim_right {; @super }
-    chars {; @super }
-    index { substr; @super }
-    to_i {; @super }
-    to_f {; @super }
-	empty? {; @super }
-	include? { substr; @super }
-	reverse {; @super }
-	replace { new; @super }
-	start_with? { prefix; @super }
-	end_with? { suffix; @super }
-	gsub { pattern, replacement; @super }
+	downcase {; @ruby }
+	upcase {; @ruby }
+	split { delimiter = nil; @ruby } # todo: Without the default nil value, .split() fails
+    slice { substr; @ruby }
+    trim {; @ruby }
+	trim_left {; @ruby }
+	trim_right {; @ruby }
+    chars {; @ruby }
+    index { substr; @ruby }
+    to_i {; @ruby }
+    to_f {; @ruby }
+	empty? {; @ruby }
+	include? { substr; @ruby }
+	reverse {; @ruby }
+	replace { new; @ruby }
+	start_with? { prefix; @ruby }
+	end_with? { suffix; @ruby }
+	gsub { pattern, replacement; @ruby }
 
-	to_md5_hash {; @super }
+	to_md5_hash {; @ruby }
 }

--- a/ore/table.ore
+++ b/ore/table.ore
@@ -1,4 +1,4 @@
-Record {
+Table {
 	table_name,
 	infer_table_name_from_class! {; @ruby }
 

--- a/src/compiler/expressions.rb
+++ b/src/compiler/expressions.rb
@@ -136,6 +136,7 @@ module Ore
 
 	class Identifier_Expr < Expression
 		attr_accessor :kind, :unpack, :scope_operator, :directive, :privacy, :binding
+		# todo: Rename @directive to @builtin
 	end
 
 	class Composition_Expr < Expression

--- a/src/compiler/parser.rb
+++ b/src/compiler/parser.rb
@@ -624,8 +624,8 @@ module Ore
 		def complete_expression expr, precedence = STARTING_PRECEDENCE
 			return expr unless expr && lexemes?
 
-			if expr.is_a?(Ore::Identifier_Expr) && expr.directive && expr.value != 'super'
-				# note: I'm intentionally skipping `super` here because a Directive_Expr assumes an expression will follow it. But in the case of @super, I want it to be a standalone expression. Maybe this warrants rewriting how directives work? Or maybe this can just stay as an implementation detail. For now it's fine.
+			if expr.is_a?(Ore::Identifier_Expr) && expr.directive && expr.value != 'ruby'
+				# note: I'm intentionally skipping `ruby` here because a Directive_Expr assumes an expression will follow it. But in the case of @ruby, I want it to be a standalone expression. Maybe this warrants rewriting how directives work? Or maybe this can just stay as an implementation detail. For now it's fine.
 				directive      = Ore::Directive_Expr.new
 				directive.name = expr
 				copy_location directive, expr

--- a/src/compiler/parser.rb
+++ b/src/compiler/parser.rb
@@ -269,7 +269,8 @@ module Ore
 			until curr? Ore::FUNCTION_DELIMITER
 				param        = Ore::Param_Expr.new
 
-				if curr? Ore::DIRECTIVE_OPERATOR and eat Ore::DIRECTIVE_OPERATOR
+				if curr? Ore::UNPACK_OPERATOR
+					eat Ore::UNPACK_OPERATOR
 					param.unpack = true
 				end
 
@@ -343,7 +344,7 @@ module Ore
 
 			it.expressions = it.expressions.compact
 
-			eat '}' and Ore.assert !curr?('}')
+			eat '}'
 
 			it
 			copy_location it, start
@@ -377,10 +378,23 @@ module Ore
 		end
 
 		def parse_composition_expr
-			start           = curr_lexeme
-			expr            = Ore::Composition_Expr.new
-			expr.operator   = eat(:operator)
-			expr.identifier = parse_identifier_expr
+			start         = curr_lexeme
+			expr          = Ore::Composition_Expr.new
+			expr.operator = eat(:operator)
+			ident         = parse_identifier_expr
+
+			while curr?('.') && peek.is(:Identifier)
+				dot_op         = eat('.')
+				right          = parse_identifier_expr
+				infix          = Ore::Infix_Expr.new
+				infix.left     = ident
+				infix.operator = dot_op
+				infix.right    = right
+				copy_location infix, ident
+				ident = infix
+			end
+
+			expr.identifier = ident
 			expr
 			copy_location expr, start
 		end
@@ -390,7 +404,7 @@ module Ore
 
 			expr = Ore::Identifier_Expr.new
 
-			if curr? DIRECTIVE_OPERATOR and eat DIRECTIVE_OPERATOR
+			if curr? BUILTIN_OPERATOR and eat BUILTIN_OPERATOR
 				expr.directive = true
 			elsif curr? SCOPE_OPERATORS
 				expr.scope_operator = parse_scope_operator
@@ -500,12 +514,12 @@ module Ore
 			start       = curr_lexeme
 			expr        = Ore::Number_Expr.new
 			expr.lexeme = eat(:number)
-			if expr.value.count('.') > 1
+			if expr.lexeme.value.count('.') > 1
 				expr                  = Ore::Array_Index_Expr.new expr
 				expr.indices_in_order = expr.lexeme.value.split '.'
 				expr.indices_in_order = expr.indices_in_order.map &:to_i
 				# It's important not to convert number.value here to anything to preserve the variant number of dots in the string. I think this'll be cool syntax, 2d_array.1.2 would be the equivalent of 2d_array[1][2].
-			elsif expr.value.include? '.'
+			elsif expr.lexeme.value.include? '.'
 				expr.type  = :float
 				expr.value = expr.value.to_f
 			else
@@ -557,7 +571,7 @@ module Ore
 			elsif curr? %w(if while unless until)
 				parse_conditional_expr
 
-			elsif curr?(:identifier, ':', :Identifier) || curr?(ANY_IDENTIFIER) || curr?(Ore::DIRECTIVE_OPERATOR, :identifier) || curr?(SCOPE_OPERATORS, ANY_IDENTIFIER) || curr?(DIRECTIVE_OPERATOR, :identifier)
+			elsif curr?(:identifier, ':', :Identifier) || curr?(ANY_IDENTIFIER) || curr?(SCOPE_OPERATORS, ANY_IDENTIFIER) || curr?(BUILTIN_OPERATOR, :identifier) || curr?(BUILTIN_OPERATOR, :Identifier) || curr?(BUILTIN_OPERATOR, :IDENTIFIER)
 				parse_identifier_expr
 
 			elsif curr?(%w( [ \( { |)) && curr?(:delimiter)

--- a/src/ore.rb
+++ b/src/ore.rb
@@ -1,7 +1,7 @@
 require_relative 'shared/constants'
 require_relative 'shared/helpers'
 require_relative 'shared/ascii'
-require_relative 'shared/super_proxies'
+require_relative 'shared/ruby_proxies'
 
 require_relative 'systems/dom_renderer'
 

--- a/src/runtime/error_formatter.rb
+++ b/src/runtime/error_formatter.rb
@@ -58,7 +58,7 @@ module Ore
 			return nil unless runtime
 
 			source_file = get_source_file
-			lines       = runtime.source_files[source_file] || []
+			lines       = runtime.cached_source_by_filename[source_file] || []
 			return nil if lines.empty?
 
 			# Determine snippet boundaries

--- a/src/runtime/errors.rb
+++ b/src/runtime/errors.rb
@@ -120,7 +120,7 @@ module Ore
 	class Url_Not_Set_For_Database_Instance < Error
 	end
 
-	class Database_Not_Set_For_Record_Instance < Error
+	class Database_Not_Set_For_Table_Instance < Error
 	end
 
 	class Type_Checking_Failed < Error

--- a/src/runtime/errors.rb
+++ b/src/runtime/errors.rb
@@ -97,11 +97,11 @@ module Ore
 		# todo: This is not printing anything to stdouts
 	end
 
-	class Missing_Super_Proxy_Declaration < Error
+	class Missing_Ruby_Proxy_Declaration < Error
 	end
 
-	class Invalid_Super_Proxy_Directive_Usage < Error
-		# @super directive only supports function and variable declarations in the body of a Type declaration
+	class Invalid_Ruby_Proxy_Directive_Usage < Error
+		# @ruby directive only supports function and variable declarations in the body of a Type declaration
 	end
 
 	class Invalid_Static_Directive_Declaration < Error

--- a/src/runtime/interpreter.rb
+++ b/src/runtime/interpreter.rb
@@ -1734,11 +1734,11 @@ module Ore
 			when 'assert'
 				condition = interpret expr.expression
 				raise "assert failed #{expr.inspect}" unless condition
-			when 'super'
-				# The @super directive evaluates to the result of calling the ruby Ruby method
+			when 'ruby'
+				# The @ruby directive evaluates to the result of calling the ruby Ruby method
 				func_scope = stack.last
 				unless func_scope.is_a? Ore::Func
-					raise Ore::Invalid_Super_Proxy_Directive_Usage.new func_scope, self
+					raise Ore::Invalid_Ruby_Proxy_Directive_Usage.new func_scope, self
 				end
 
 				func_name        = func_scope.name
@@ -1761,7 +1761,7 @@ module Ore
 				end
 
 				unless target.respond_to? proxy_method
-					raise Ore::Missing_Super_Proxy_Declaration.new expr, self
+					raise Ore::Missing_Ruby_Proxy_Declaration.new expr, self
 				end
 
 				result = target.send proxy_method, *func_scope.arguments
@@ -1816,8 +1816,8 @@ module Ore
 				# todo: Allow builtins to be extended by the user. Requirements would be:
 				#   1) Create type in Ore
 				#   2) Create equivalent type in scopes.rb or similar
-				#   3) Make sure functions which use the @super expression in its body are named in to match the Ore::Type "proxy_#{func_name}"
-				# For example, `String { upcase {; @super } }` maps to `Ore::String@super_upcase`
+				#   3) Make sure functions which use the @ruby expression in its body are named in to match the Ore::Type "proxy_#{func_name}"
+				# For example, `String { upcase {; @ruby } }` maps to `Ore::String@ruby_upcase`
 				raise Ore::Invalid_Directive_Usage.new(expr, self)
 			end
 		end

--- a/src/runtime/interpreter.rb
+++ b/src/runtime/interpreter.rb
@@ -4,20 +4,22 @@ require 'json'
 
 module Ore
 	class Interpreter
-		attr_accessor :input, :lexer, :parser, :load_standard_library, :stack, :routes, :servers, :onclick_handlers, :input_elements, :loaded_files, :source_files, :last_output
+		attr_accessor :input, :lexer, :parser, :load_standard_library, :stack, :route_function_handlers_by_route_name, :servers, :dom_onclick_function_handlers, :dom_input_elements, :cached_expressions_by_filepath, :cached_source_by_filename, :last_output
 
 		def initialize
+			@cached_expressions_by_filepath        = {} # {filepath: [Ore::Expression]}
+			@cached_source_by_filename             = {} # {filepath: String}
+			@dom_input_elements                    = {} # {element_hash: Ore::Instance} for inputs/textareas
+			@dom_onclick_function_handlers         = {} # {handler_hash: Ore::Func}
+			@route_function_handlers_by_route_name = {} # {route: Ore::Route}
+
 			@load_standard_library = true
 			@input                 = [] # [Ore::Expression]
 			@stack                 = [] # [Ore::Scope]
 			@servers               = [] # [Ore::Server]
-			@routes                = {} # {route: Ore::Route}
-			@loaded_files          = {} # {filename: [Ore::Expression]}
-			@source_files          = {} # {filepath: String} for error reporting
-			@onclick_handlers      = {} # {handler_hash: Ore::Func}
-			@input_elements        = {} # {element_hash: Ore::Instance} for inputs/textareas
-			@lexer                 = Lexer.new
-			@parser                = Parser.new
+
+			@lexer  = Lexer.new
+			@parser = Parser.new
 		end
 
 		def run source_code
@@ -81,16 +83,16 @@ module Ore
 
 			push_scope into_scope
 
-			unless @loaded_files[resolved_path]
+			unless @cached_expressions_by_filepath[resolved_path]
 				code = File.read resolved_path
 				register_source resolved_path, code
-				@lexer.input                 = code
-				@parser.input                = @lexer.output
-				@loaded_files[resolved_path] = @parser.output
+				@lexer.input                                   = code
+				@parser.input                                  = @lexer.output
+				@cached_expressions_by_filepath[resolved_path] = @parser.output
 			end
 
 			saved  = @input
-			@input = @loaded_files[resolved_path]
+			@input = @cached_expressions_by_filepath[resolved_path]
 			result = output # note: Okay to call #output directly here
 			@input = saved
 
@@ -119,19 +121,19 @@ module Ore
 		end
 
 		def register_source filepath, source_code
-			resolved               = filepath ? File.expand_path(filepath) : '<inline>'
-			source_files[resolved] = source_code.lines.map(&:chomp)
+			resolved                            = filepath ? File.expand_path(filepath) : '<inline>'
+			cached_source_by_filename[resolved] = source_code.lines.map(&:chomp)
 		end
 
 		def add_onclick_handler handler
-			key                   = handler.hash
-			onclick_handlers[key] = handler
+			key                                = handler.hash
+			dom_onclick_function_handlers[key] = handler
 			key
 		end
 
 		def add_input_element instance
-			key                 = instance.hash
-			input_elements[key] = instance
+			key                     = instance.hash
+			dom_input_elements[key] = instance
 			key
 		end
 
@@ -314,14 +316,14 @@ module Ore
 
 			if path_string.start_with?("/onclick/")
 				object_id = path_parts.last.to_i
-				handler   = onclick_handlers[object_id]
+				handler   = dom_onclick_function_handlers[object_id]
 				if handler
 					begin
 						if request.body && !request.body.empty?
 							json_body = JSON.parse request.body rescue {}
 							inputs = json_body['inputs'] || {}
 							inputs.each do |element_id, value|
-								input_instance = input_elements[element_id.to_i]
+								input_instance = dom_input_elements[element_id.to_i]
 								input_instance.declare 'value', value if input_instance
 							end
 						end
@@ -1371,7 +1373,7 @@ module Ore
 				enclosing_type.routes[route_key] = route
 			end
 
-			@routes[route_key] = route
+			@route_function_handlers_by_route_name[route_key] = route
 			stack.last.declare route_key, route
 
 			route

--- a/src/runtime/interpreter.rb
+++ b/src/runtime/interpreter.rb
@@ -841,6 +841,13 @@ module Ore
 			else
 				# @copypaste from #interp_dot_scope because we already interpreted expr as 'left'. If #interp_dot_scope interprets expr again, we end up with duplicate duplicate isntnatiations
 
+				if expr.right.instance_of? Ore::Type_Expr
+					push_scope receiver
+					result = interpret expr.right
+					pop_scope
+					return result
+				end
+
 				unless expr.right.instance_of? Ore::Identifier_Expr
 					raise Ore::Invalid_Dot_Infix_Right_Operand.new(expr.right, self)
 				end
@@ -996,7 +1003,7 @@ module Ore
 					return interp_func_body overload_func, call
 				end
 
-				if expr.left.value == Ore::DIRECTIVE_OPERATOR
+				if expr.left.value == Ore::BUILTIN_OPERATOR # todo: Choose a different name for this, and a different character to use. @ is now gonna be exclusively "builtin" operator.
 					case expr.operator.value
 					when '+='
 						right = interpret expr.right
@@ -1156,21 +1163,18 @@ module Ore
 		end
 
 		def interp_type expr
-			type                 = Ore::Type.new expr.name.value
-			type.expressions     = expr.expressions
+			existing = stack.last.has?(expr.name.value) && stack.last[expr.name.value]
+			type     = existing.is_a?(Ore::Type) ? existing : Ore::Type.new(expr.name.value)
+
+			type.expressions     = (type.expressions || []) + expr.expressions
 			type.enclosing_scope = stack.last
 
 			ore_name = "Ore::#{expr.name.value}"
 			defined  = Object.const_defined? ore_name
 			link_instance_to_type type, expr.name.value if defined
 
-			if type.types
-				type.types << type.name
-			else
-				type.types = [type.name]
-			end
-
-			# todo: Make @types a set
+			type.types ||= []
+			type.types << type.name
 			type.types = type.types.uniq
 
 			push_then_pop type do |scope|
@@ -1482,7 +1486,7 @@ module Ore
 		def interp_composition expr
 			# These are interpreted sequentially, so there are no precedence rules. I think that'll be better in the long term because there's no magic behind their evaluation. You can ensure the correct outcome by using these operators to form the types you need.
 
-			right      = maybe_instance interp_identifier expr.identifier
+			right      = maybe_instance interpret expr.identifier
 			unless right.is_a? Ore::Scope
 				# todo: Proper error
 				raise "Expected a scope to compose with, got #{right.inspect}"

--- a/src/runtime/scopes.rb
+++ b/src/runtime/scopes.rb
@@ -99,7 +99,7 @@ module Ore
 
 	class String < Instance
 		require 'digest/md5'
-		extend Super_Proxies
+		extend Ruby_Proxies
 
 		attr_accessor :value
 
@@ -149,7 +149,7 @@ module Ore
 
 	# note: Be sure to prefix with Ore:: whenever referencing this Array type to prevent ambiguity with Ruby's ::Array!
 	class Array < Instance
-		extend Super_Proxies
+		extend Ruby_Proxies
 		attr_accessor :values
 
 		def initialize values = []
@@ -204,7 +204,7 @@ module Ore
 	end
 
 	class Dictionary < Instance
-		extend Super_Proxies
+		extend Ruby_Proxies
 		attr_accessor :dict
 
 		def initialize dict = nil
@@ -256,7 +256,7 @@ module Ore
 	end
 
 	class Number < Instance
-		extend Super_Proxies
+		extend Ruby_Proxies
 		attr_accessor :numerator, :denominator, :type
 
 		def + other
@@ -384,7 +384,7 @@ module Ore
 	end
 
 	class Record < Instance
-		extend Super_Proxies
+		extend Ruby_Proxies
 
 		def proxy_infer_table_name_from_class!
 			require 'sequel/extensions/inflector.rb'

--- a/src/runtime/scopes.rb
+++ b/src/runtime/scopes.rb
@@ -383,7 +383,7 @@ module Ore
 		attr_accessor :webrick_response
 	end
 
-	class Record < Instance
+	class Table < Instance
 		extend Ruby_Proxies
 
 		def proxy_infer_table_name_from_class!
@@ -404,7 +404,7 @@ module Ore
 
 		# @return [Sequal::SQLite::Dataset]
 		def table
-			raise Ore::Database_Not_Set_For_Record_Instance unless database
+			raise Ore::Database_Not_Set_For_Table_Instance unless database
 
 			database['connection'][table_name]
 		end

--- a/src/shared/constants.rb
+++ b/src/shared/constants.rb
@@ -1,5 +1,5 @@
 module Ore
-	DIRECTIVE_OPERATOR          = '@'
+	BUILTIN_OPERATOR            = '@'
 	UNPACK_OPERATOR             = '@' # todo: Pick a different symbol
 	NIL_INIT_POSTFIX            = ','
 	FUNCTION_DELIMITER          = ';'

--- a/src/shared/ruby_proxies.rb
+++ b/src/shared/ruby_proxies.rb
@@ -1,4 +1,4 @@
-module Super_Proxies
+module Ruby_Proxies
 	def proxy_delegate object_name
 		define_method "_proxy_delegate_" do |*args|
 			send object_name

--- a/test/database_test.rb
+++ b/test/database_test.rb
@@ -8,7 +8,7 @@ require 'securerandom'
 
 class Database_Test < Base_Test
 	DATABASE = "@use 'ore/database.ore'"
-	RECORD   = "@use 'ore/record.ore'"
+	RECORD   = "@use 'ore/table.ore'"
 
 	def before_setup
 		@filepath = "./temp#{SecureRandom.hex}.db"
@@ -64,10 +64,10 @@ class Database_Test < Base_Test
 	def test_inferring_record_table_name
 		out = Ore.interp <<~ORE
 		    #{RECORD}
-			r = Record()
+			r = Table()
 			r.table_name
 
-			Thing | Record {}
+			Thing | Table {}
 			t = Thing()
 			t.infer_table_name_from_class!()
 			(r, t)
@@ -115,7 +115,7 @@ class Database_Test < Base_Test
 
 			db.create_table('users' { id: 'primary_key', name: 'String' })
 
-			User | Record {
+			User | Table {
 				./database = db
 				table_name = 'users'
 			}
@@ -162,7 +162,7 @@ class Database_Test < Base_Test
 
 			db.create_table('users', { id: 'primary_key', name: 'String' })
 
-			User | Record {
+			User | Table {
 				./database = db
 				table_name = 'users'
 			}
@@ -181,7 +181,7 @@ class Database_Test < Base_Test
 
 			db.create_table('users', { id: 'primary_key', name: 'String' })
 
-			User | Record {
+			User | Table {
 				./database = db
 				table_name = 'users'
 			}
@@ -200,7 +200,7 @@ class Database_Test < Base_Test
 
 			db.create_table('users', { id: 'primary_key', name: 'String' })
 
-			User | Record {
+			User | Table {
 				./database = db
 				table_name = 'users'
 			}
@@ -217,7 +217,7 @@ class Database_Test < Base_Test
 
 			db.create_table('items', { id: 'primary_key', name: 'String', kind: 'String' })
 
-			Item | Record {
+			Item | Table {
 				./database = db
 				table_name = 'items'
 			}

--- a/test/interpreter_test.rb
+++ b/test/interpreter_test.rb
@@ -1804,16 +1804,16 @@ class Interpreter_Test < Base_Test
 		out = Ore.interp "'WALT!'.downcase()"
 		assert_equal "walt!", out
 
-		assert_raises Ore::Invalid_Super_Proxy_Directive_Usage do
-			Ore.interp "@super whatever"
+		assert_raises Ore::Invalid_Ruby_Proxy_Directive_Usage do
+			Ore.interp "@ruby whatever"
 		end
 
-		assert_raises Ore::Invalid_Super_Proxy_Directive_Usage do
-			Ore.interp "@super 123"
+		assert_raises Ore::Invalid_Ruby_Proxy_Directive_Usage do
+			Ore.interp "@ruby 123"
 		end
 
-		assert_raises Ore::Invalid_Super_Proxy_Directive_Usage do
-			Ore.interp "Type { @super 123, }"
+		assert_raises Ore::Invalid_Ruby_Proxy_Directive_Usage do
+			Ore.interp "Type { @ruby 123, }"
 		end
 	end
 
@@ -2111,7 +2111,7 @@ class Interpreter_Test < Base_Test
 		code = <<~CODE
 		    String | String {
 		        upcase {;
-		        	@super + " (SWIZZLED)"
+		        	@ruby + " (SWIZZLED)"
 		        }
 		    }
 			"test".upcase()

--- a/test/proxies_test.rb
+++ b/test/proxies_test.rb
@@ -4,8 +4,8 @@ require_relative 'base_test'
 
 class ProxiesTest < Base_Test
 	def test_invalid_proxy_directive_usage
-		assert_raises Ore::Invalid_Super_Proxy_Directive_Usage do
-			Ore.interp '@super'
+		assert_raises Ore::Invalid_Ruby_Proxy_Directive_Usage do
+			Ore.interp '@ruby'
 		end
 	end
 

--- a/test/regression_test.rb
+++ b/test/regression_test.rb
@@ -374,11 +374,11 @@ class Regression_Test < Base_Test
 			ORE
 		end
 
-		assert_raises Ore::Database_Not_Set_For_Record_Instance do
+		assert_raises Ore::Database_Not_Set_For_Table_Instance do
 			Ore.interp <<~ORE
-			    @use 'ore/record.ore'
+			    @use 'ore/table.ore'
 
-			    Record.find(1)
+			    Table.find(1)
 			ORE
 		end
 	end

--- a/test/regression_test.rb
+++ b/test/regression_test.rb
@@ -363,7 +363,7 @@ class Regression_Test < Base_Test
 	end
 
 	def test_broken_static_declarations
-		refute_raises Ore::Missing_Super_Proxy_Declaration do
+		refute_raises Ore::Missing_Ruby_Proxy_Declaration do
 			Ore.interp <<~ORE
 			    Thing {
 			    	./abc,

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -70,7 +70,7 @@ class Server_Test < Base_Test
 		interpreter = Ore::Interpreter.new
 		interpreter.run code
 
-		assert_equal 2, interpreter.routes.count
+		assert_equal 2, interpreter.route_function_handlers_by_route_name.count
 	end
 
 	def test_server_runner_initialization
@@ -120,7 +120,7 @@ class Server_Test < Base_Test
 		interpreter = Ore::Interpreter.new
 		interpreter.run code
 
-		assert_equal 2, interpreter.routes.count
+		assert_equal 2, interpreter.route_function_handlers_by_route_name.count
 	end
 
 	def test_route_matching
@@ -147,7 +147,7 @@ class Server_Test < Base_Test
 
 		interpreter     = Ore::Interpreter.new
 		server_instance = interpreter.run code
-		routes          = interpreter.routes
+		routes          = interpreter.route_function_handlers_by_route_name
 
 		matched = interpreter.match_route 'get', ['users', '123'], routes
 		assert matched
@@ -181,7 +181,7 @@ class Server_Test < Base_Test
 
 		interpreter = Ore::Interpreter.new
 		interpreter.run code
-		route      = interpreter.routes.values.first
+		route      = interpreter.route_function_handlers_by_route_name.values.first
 		path_parts = ['users', '42', 'posts', '99']
 		url_params = interpreter.extract_url_params path_parts, route
 


### PR DESCRIPTION
- Rename Record -> Table throughout (ore file, scopes, errors, tests, examples)
- Type definitions now merge when re-opened in the same scope instead of replacing
- Composition target supports dot notation (e.g. | some.Module.Bar {})
- Use interpret instead of interp_identifier in composition so dot chains evaluate correctly
- Handle Type_Expr on right side of dot infix
- Fix number expression reading lexeme.value before value was set
- Rename DIRECTIVE_OPERATOR constant to BUILTIN_OPERATOR
- Add empty date.ore / date_time.ore stubs and game.ore example